### PR TITLE
WIP: basic framework for layerwise spn computation

### DIFF
--- a/src/spn/gpu/Edges.py
+++ b/src/spn/gpu/Edges.py
@@ -1,0 +1,47 @@
+import torch
+import numpy as np
+
+EPSILON = 0.00001
+
+
+class ProductEdges():
+    '''
+    Handing product edges via masking and parent and children nodes
+    '''
+
+    def __init__(self, child, parent, mask):
+        '''
+        Initialize a set of product edges
+        :param child: child layer, with size: num_in
+        :param parent: parent layer, with size: num_out
+        :param mask: masks out unconnected edges, with size: num_in x num_out
+        '''
+        self.parent = parent
+        self.child = child
+        self.mask = mask
+
+
+class SumEdges():
+    '''
+    Handing the sum edges with the weights and the masking layers
+    '''
+
+    def __init__(self, child, parent, weights, mask):
+        '''
+        Initialize a set of product edges
+        :param child: child layer, with size: num_in
+        :param parent: parent layer, with size: num_out
+        :param weights: size: num_in x num_out
+        :param mask: masks out unconnected edges, with size: num_in x num_out
+        '''
+        self.parent = parent
+        self.child = child
+        self.weights = weights
+        self.mask = mask
+
+    def sum_weight_hook(self):
+        if self.weights.size()[0] == 30:
+            # pdb.set_trace()
+            pass
+
+        self.weights.data = self.weights.data.clamp(min=EPSILON)

--- a/src/spn/gpu/Network.py
+++ b/src/spn/gpu/Network.py
@@ -1,0 +1,237 @@
+'''
+Constructing the Network in PyTorch's Backend
+'''
+import torch
+from torch.autograd import Variable as Variable
+import numpy as np
+
+import os.path
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from src import Nodes, Edges
+
+
+class Network(torch.nn.Module):
+    '''
+    A particular SPN structure, whose parameters are in Param
+    '''
+
+    def __init__(self, is_cuda=False):
+        '''
+        Initialize the lists of nodes and edges
+        '''
+        super(Network, self).__init__()
+        self.leaflist = list()  # Leaf list or dict
+        self.nodelist = list()  # Variable list
+        self.edgelist = list()  # Edgelist
+        self.is_cuda = is_cuda
+
+        return
+
+    def forward(self):
+        '''
+        Override torch.nn.Module.forward
+        :return: last layer's values
+        '''
+        for layer in self.leaflist:
+            val = layer()
+
+        for layer in self.nodelist:
+            val = layer()
+
+        return val
+
+    def feed(self, val_dict={}, cond_mask_dict={}):
+        '''
+        Feed input values
+        :param val_dict: A dictionary containing <variable, value> pairs
+        :param cond_mask_dict: A dictionary containing <variable, mask> pairs
+            A mask of 1 indicates the variable is conditioned
+        :return: None
+        For variables not in `cond_dict`, assume not conditioned (i.e., query variables)
+        For variables not in `val_dict`, assume to be marginalized out (i.e., all ones)
+        '''
+
+        for k in val_dict:
+            k.feed_val(val_dict[k])
+        for k in cond_mask_dict:
+            k.feed_marginalize_mask(cond_mask_dict[k])
+
+    def var(self, tensor, requires_grad=False):
+        if self.is_cuda:
+            tensor = tensor.cuda()
+        return Variable(tensor, requires_grad=requires_grad)
+
+    def parameter(self, tensor, requires_grad=False):
+        if self.is_cuda:
+            tensor = tensor.cuda()
+        return torch.nn.Parameter(tensor, requires_grad=requires_grad)
+
+    def AddGaussianNodes(self, mean, std,
+                         isReused=False,
+                         parameters=None):
+        '''
+        Add a set of Bernoulli nodes
+        :param mean: mean of Gaussian
+        :param std:  std  of Gaussian
+        :param isReused: if the parameters are reused
+        :param param: the global parameter set of SPN
+        :return: the Gaussian nodes
+        For Node i, the probability of Node i being 1 is p_Bern[i].
+        '''
+
+        if isReused is None:
+            print('not implemented')
+
+        elif not isReused:
+            mean = self.parameter(torch.from_numpy(mean), requires_grad=True)
+
+            logstd = self.parameter(torch.from_numpy(np.log(std)), requires_grad=True)
+        # else if isReused
+        # do nothing
+
+        _nodes = Nodes.GaussianNodes(is_cuda=self.is_cuda, mean=mean, logstd=logstd)
+
+        if not isReused:
+            parameters.add_param(mean, _nodes.mean_proj_hook)
+            parameters.add_param(logstd, _nodes.std_proj_hook)
+        self.leaflist.append(_nodes)
+        return _nodes
+
+    def AddSumEdges(self, lower, upper, weights=None, mask=None, isReused=False,
+                    parameters=None):
+        '''
+        Add an edge: lower -> upper with weights weight
+        :param lower: lower layer
+        :param upper: upper layer
+        :param weights: size N_lower x N_upper.
+             `weights` is a numpy array if `isReused` is `False`
+             `weights` is a instance of `torch.nn.Parameters` if `isReused` in `True`
+             if `weights` is `None`, randomly inistalize weights according to some criterion
+        :param mask: numpy aray with size <N_lower x N_upper> masking out non-connected edges (a mask of 0 indicates disconnected edge)
+        :param isReused: Boolean. If is reused, the parameters are not added to `param`
+        :param param: An instance of Param
+        :return: (edge, para)
+         edge is an instance of Edges.SumEdges
+         para is an instance of torch.nn.Parameters
+        '''
+
+        if weights is None:
+            # TODO: initialize weights according to some criterion
+            pass
+        elif not isReused:
+            if mask is not None:
+                mask = self.var(torch.from_numpy(mask), requires_grad=False)
+            else:  # if mask is None:
+                mask = self.var(torch.from_numpy(
+                    np.ones(weights.shape).astype('float32'))).detach()
+
+            weights = self.parameter(torch.from_numpy(weights), requires_grad=True)
+
+        # else isReused:
+        # weights are already an instance of `torch.nnParameters`, and have been in `param.para_list`
+        # do nothing
+
+        _edges = Edges.SumEdges(lower, upper, weights, mask)
+        upper.child_edges.append(_edges)
+        lower.parent_edges.append(_edges)
+
+        if not isReused:
+            parameters.add_param(weights, _edges.sum_weight_hook)
+
+        return _edges, weights
+
+    def AddSumNodes(self, num):
+        '''
+        Add a set of sum nodes to Network
+        :param num: the number of sum nodes
+        :return: An instance of Nodes.SumNodes
+        '''
+        _nodes = Nodes.SumNodes(is_cuda=self.is_cuda, num=num)
+        self.nodelist.append(_nodes)
+        return _nodes
+
+    def AddProductNodes(self, num):
+        '''
+        Add a set of product nodes to Network
+        :param num: the number of product nodes
+        :return: An instance of Nodes.ProductNodes
+        '''
+        _nodes = Nodes.ProductNodes(is_cuda=self.is_cuda, num=num)
+        self.nodelist.append(_nodes)
+        return _nodes
+
+    def AddSumNodeWeights(self, weights, parameters=None):
+        '''
+        :param weights: the weights for this SPN
+        '''
+        self.weights = self.parameter(torch.from_numpy(weights), requires_grad=True)
+
+        parameters.add_param(self.weights, hook=self.SumNodeWeightHook)
+
+    def ComputeUnnormalized(self, val_dict=None, marginalize_dict={}):
+        '''
+        Compute unnormalized measure
+        :param val_dict: A dictionary containing <variable, value> pairs
+            X U Y = variables
+        :param cond_mask_dict: A dictionary containing <variable, mask> pairs
+            A mask of 1 indicates the variable is conditioned (i.e., X)
+            A mask of 0 indicates the variable is unconditioned (i.e., Y)
+        :return: a scalar, the unnormalized measure p_tilde(Y|X)
+        For variables not in `cond_mask_dict`, assume not conditioned (i.e., Y)
+        For variables not in `val_dict`, assumed to be marginalized out
+        '''
+        self.feed(val_dict, marginalize_dict)
+        return np.exp(self().data.cpu().numpy())
+
+    def ComputeLogUnnormalized(self, val_dict=None, marginalize_dict={}):
+        '''
+        Compute unnormalized measure
+        :param val_dict: A dictionary containing <variable, value> pairs
+            X U Y = variables
+        :param cond_mask_dict: A dictionary containing <variable, mask> pairs
+            A mask of 1 indicates the variable is conditioned (i.e., X)
+            A mask of 0 indicates the variable is unconditioned (i.e., Y)
+        :return: a scalar, the unnormalized measure p_tilde(Y|X)
+        For variables not in `cond_mask_dict`, assume not conditioned (i.e., Y)
+        For variables not in `val_dict`, assumed to be marginalized out
+        '''
+
+        self.feed(val_dict, marginalize_dict)
+
+        return self()
+
+    def ComputeProbability(self, val_dict=None, cond_mask_dict={}, grad=False,
+                           log=False, is_negative=False):
+        '''
+        Compute unnormalized measure
+        :param val_dict: A dictionary containing <variable, value> pairs
+            X U Y = variables
+        :param cond_mask_dict: A dictionary containing <variable, mask> pairs
+            A mask of 1 indicates the variable is conditioned (i.e., X)
+            A mask of 0 indicates the variable is unconditioned (i.e., Y)
+        :return: a scalar, the unnormalized measure p_tilde(Y|X)
+        For variables not in `cond_mask_dict`, assume not conditioned (i.e., Y)
+        For variables not in `val_dict`, assumed to be marginalized out
+        '''
+        # TODO Not implemented: cond_mask_dict and/or val_dict not complete
+
+        log_p_tilde = self.ComputeLogUnnormalized(val_dict)
+
+        marginalize_dict = {}
+        for k in cond_mask_dict:
+            marginalize_dict[k] = 1 - cond_mask_dict[k]
+
+        log_Z = self.ComputeLogUnnormalized(val_dict, marginalize_dict)
+
+        J = torch.sum(- log_p_tilde + log_Z)  # negative log-likelihood
+
+        if grad:
+            J.backward()
+
+        prob = log_p_tilde.data.cpu().numpy() - log_Z.data.cpu().numpy()
+        if not log:
+            prob = np.exp(prob)
+        return prob

--- a/src/spn/gpu/Nodes.py
+++ b/src/spn/gpu/Nodes.py
@@ -1,0 +1,213 @@
+import torch
+from torch.autograd import Variable as Variable
+import numpy as np
+
+
+class Nodes(torch.nn.Module):
+    '''
+    Base class for SPN nodes (also called a layer).
+    '''
+
+    def __init__(self, is_cuda=False):
+        '''
+        Initialize nodes.
+        :param is_cuda: True when computation should be done with CUDA (GPU).
+        '''
+        super(Nodes, self).__init__()
+
+        self.is_cuda = is_cuda
+
+    def var(self, tensor, requires_grad=False):
+        '''
+        Returns PyTorch Variable according to this node's settings.
+        Currently only determines if the tensor is in GPU.
+        :return: PyTorch Variable
+        '''
+        if self.is_cuda:
+            tensor = tensor.cuda()
+
+        return Variable(tensor, requires_grad)
+
+
+class SumNodes(Nodes):
+    '''
+    The class of a set of sum nodes (also called a sum layer)
+    '''
+
+    def __init__(self, is_cuda, num=1):
+        '''
+        Initialize a set of sum nodes
+        :param num: the number of sum nodes
+        '''
+        Nodes.__init__(self, is_cuda).__init__()
+        self.num = num
+        self.child_edges = []
+        self.parent_edges = []
+        self.scope = None  # todo
+        self.is_cuda = is_cuda
+
+    def forward(self):
+        '''
+        Overrides the method in torch.nn.Module
+        :return: the value of this layer
+        '''
+        batch = self.child_edges[0].child.val.size()[0]
+
+        self.val = self.var(torch.zeros(batch, self.num))
+        # with size: <1 x Ny>
+
+        # we are about to subtract the maximum value in all child nodes
+        # to make sure the exp is operated on non-positive values
+        for idx, e in enumerate(self.child_edges):
+            # TODO: be careful when donig batched computation
+            tmpmax = torch.max(torch.max(e.child.val))
+            if idx == 0:
+                maxval = tmpmax
+            else:
+                maxval = torch.max(maxval, tmpmax)
+        maxval.detach()  # disconnect during bp. any constant works here
+
+        for e in self.child_edges:
+
+            # e.child.val, size: <1 x Nx>
+            # weights, size: <Nx x Ny>
+
+            # log space computation:
+
+            tmp = e.child.val - maxval  # log(x/max)
+            # with size <1 x Nx>
+
+            tmp = torch.exp(tmp)  # x/max
+            # with size <1 x Nx>
+            trueweights = e.weights * e.mask
+            # with size <Nx x Ny>
+            self.val += torch.mm(tmp, trueweights)  # <w, x>/max)
+            # with size <1 x Ny>
+
+            # original space
+            # self.val += torch.mm(e.child.val, e.weights)
+
+        # log space only:
+
+        small_num = torch.exp(torch.FloatTensor([-75]))[0]
+        if self.is_cuda:
+            small_num = small_num.cuda()
+
+        self.val += small_num
+        self.val = torch.log(self.val)  # log( wx / max)
+        self.val += maxval
+        return self.val
+
+
+class ProductNodes(Nodes):
+    '''
+    The class of a set of product nodes (also called a product layer)
+    '''
+
+    def __init__(self, is_cuda, num=1):
+        '''
+        Initialize a set of sum nodes
+        :param num: the number of sum nodes
+        '''
+        Nodes.__init__(self, is_cuda).__init__()
+        self.num = num
+        self.child_edges = []
+        self.parent_edges = []
+        self.scope = None  # todo
+        self.val = None
+        self.samples = None
+
+    def forward(self):
+        '''
+        Overrides the method in torch.nn.Module
+        :return: the value of this layer
+        '''
+        # TODO: compute in the log space
+        # however, we should first check the validity of log 0 for onehot leaf nodes
+        batch = self.child_edges[0].child.val.size()[0]
+        val = self.var(torch.zeros((batch, self.num)))
+        # with size: batch x num_lower
+        for e in self.child_edges:
+            # log space
+            val += torch.mm(e.child.val, e.mask)
+            '''
+            # original space
+            num_child = e.child.num  # Is this variable going to be used?
+            # child.val has size: <1 x Nx>
+            # e.mask    has size: <Nx x Ny>  (suppose x -> y)
+            tmp_val = torch.t(e.child.val.repeat(self.num, 1))
+            # with size: <Nx x Ny>
+            tmp_val = torch.pow(tmp_val, e.mask)
+            # with size: <Nx x Ny>
+            tmp_val = tmp_val.prod(0)
+            # with size: <1 x Ny>
+            val = val * tmp_val
+            '''
+        self.val = val
+        return val
+
+
+#######################
+# Leaf nodes
+
+class GaussianNodes(Nodes):
+    '''
+    The class of a set of Gaussian leaf nodes
+    '''
+
+    def __init__(self, is_cuda, mean, logstd):
+        '''
+        Initialize a set of Guassian nodes with parameters (mu, diag(sigma))
+        :param mu:
+        :param sigma:
+        '''
+        Nodes.__init__(self, is_cuda).__init__()
+
+        self.num = 1          # the number of Gaussian nodes
+        self.mean = mean
+        self.logstd = logstd
+        self.is_cuda = is_cuda
+        self.parent_edges = []
+        self.debug = False
+        pass
+
+    def forward(self):
+        '''
+        Overrides the method in torch.nn.Module
+        :return: the value of current layer
+        compute log p(x; mu, sigma)
+        '''
+
+        if isinstance(self.input, np.ndarray):
+            self.input = torch.from_numpy(self.input.astype('float32'))
+            self.input = self.var(self.input)
+
+        x_mean = self.input - self.mean
+        std = torch.exp(self.logstd)
+        var = std * std
+
+        self.val = (1 - self.marginalize_mask) * (- (x_mean) * (x_mean) /
+                                                  2.0 / var - self.logstd - 0.91893853320467267)
+        # Note: if marginalized out, log p = 0
+
+        return self.val
+
+    def feed_val(self, x, marginalize_mask=None):
+        self.input = x
+        batch = x.shape[0]
+        if marginalize_mask is None:
+            # do not marginalize
+            marginalize_mask = np.zeros((batch, self.num), dtype='float32')
+        # else if marginalize_mask specified:
+            # do nothing
+        self.marginalize_mask = self.var(torch.from_numpy(marginalize_mask.astype('float32')))
+        pass
+
+    def feed_marginalize_mask(self, mask):
+        self.marginalize_mask = self.var(torch.from_numpy(mask.astype('float32')))
+
+    def mean_proj_hook(self):
+        pass
+
+    def std_proj_hook(self):
+        self.logstd.data = self.logstd.data.clamp(min=-85)

--- a/src/spn/gpu/Param.py
+++ b/src/spn/gpu/Param.py
@@ -1,0 +1,85 @@
+'''
+Handing the parameter space operations in SPFlow PyTorch Backend
+'''
+
+import torch
+import numpy as np
+
+
+class Param():
+    '''
+    Global status of the model parameters
+    Currently keeps tracks of parameters only and allows us to perform
+    operations on the PyTorch parameter space.
+    TODO: Add more notes about the capabilities of the parameter space and how
+     exactly to utilize it fully
+    '''
+    parameter_list = None  # Parameter list
+    # refer to `https://pytorch.org/docs/stable/nn.html`
+
+    def __init__(self):
+        '''
+        Initlize the parameter list
+        '''
+        self.parameter_list = torch.nn.ParameterList()
+        self.hook_list = []
+
+    def add_param(self, parameter, hook):
+        '''
+        Add a set of parameters to the world
+        :param parameter: An instance of torch.nn.Parameters
+        :param mask:
+        :return: None
+        If mask = None: do not normalize the corresponding parameter
+        Else: normalize the parameter as a probabilistic distribution according to the
+              variables indicated in the masks
+        '''
+
+        self.parameter_list.append(parameter)
+
+        # hooks are a pytorch specific construct that can be called in the
+        # forward and backward passes to allow for debugging through prints, etc
+
+        if hook is not None:
+            self.hook_list.append(hook)
+
+    def register(self, model):
+        for idx, parameter in enumerate(self.parameter_list):
+
+            model.register_parameter('para_' + str(idx), parameter)
+            self.model = model
+
+    def get_unrolled_para(self):
+        pvector = np.array([])
+
+        for parameter in self.parameter_list:
+            pvector = np.concatenate((pvector, parameter.data.numpy().reshape(-1)))
+        return pvector.reshape((-1, 1))
+
+    def get_unrolled_grad(self):
+        pvector = np.array([])
+
+        for parameter in self.parameter_list:
+            pvector = np.concatenate((pvector, parameter.grad.data.numpy().reshape(-1)))
+
+        return pvector.reshape((-1, 1))
+
+    def get_size(self):
+        '''
+        :return: the shape of the parameter set
+        '''
+        return len(self.parameter_list)
+
+    def set_shape(self, dims):
+        '''
+        :param dims: Dims is a tuple that has the parameters that determines the
+        new shape of the parameter list
+        :return: The new shape of the parameter list and modifies the actual
+        dimensions of the parameter list
+        '''
+        self.parameter_list = np.array(self.parameter_list).reshape()
+
+
+if __name__ == '__main__':
+
+    param = Param()

--- a/src/spn/gpu/PyTorch.py
+++ b/src/spn/gpu/PyTorch.py
@@ -1,0 +1,64 @@
+import numpy as np
+import torch
+import torch.nn as nn
+
+from spn.algorithms.TransformStructure import Copy
+from spn.structure.Base import Product, Sum, eval_spn_bottom_up
+from spn.structure.leaves.histogram.Histograms import Histogram
+from spn.structure.leaves.histogram.Inference import histogram_likelihood
+from spn.structure.leaves.parametric.Parametric import Gaussian
+
+
+def log_prod_to_pytorch_graph(node, children, data_placeholder=None, variable_dict=None, log_space=True, dtype=np.float32):
+    assert log_space
+    tensor_sum = 0
+    for child in children:
+        tensor_sum += child
+    return tensor_sum
+
+
+def log_sum_to_pytorch_graph(node, children, data_placeholder=None, variable_dict=None, log_space=True, dtype=np.float32):
+    assert log_space
+    softmax_inverse = np.log(node.weights / np.max(node.weights)).astype(dtype)
+    pytorch_weights = nn.s
+
+
+def spn_to_pytorch_graph(node, data, batch_size=None, node_pytorch_graph, log_space=True, dtype=None):
+    if not dtype:
+        dtype = data.dtype
+
+    variable_dict = {}
+    # we don't need to create a placeholder in pytorch
+    # instead we create a torch.tensor of the data shape
+    data_placeholder = torch.zeros([batch_size, data.shape[1]], dtype=dtype)
+    pytorch_graph = eval_spn_bottom_up(node=node, eval_functions=node_pytorch_graph, data_placeholder=data_placeholder,
+                                       log_space=log_space, variable_dict=variable_dict, dtype=dtype)
+
+    return pytorch_graph, data_placeholder, variable_dict
+
+
+def eval_pytorch(spn, data, save_graph_path=None, dtype=np.float32):
+    pytorch_graph, placeholder, _ = spn_to_pytorch_graph(spn, data, dtype=dtype)
+    return eval_pytorch_graph(pytorch_graph, placeholder, data, save_graph_path)
+
+
+def test_eval_gaussian():
+    np.random.seed(17)
+    data = np.random.normal(10, 0.01, size=2000).tolist() + \
+        np.random.normal(30, 10, size=2000).tolist()
+    data = np.array(data).reshape((-1, 10))
+    data = data.astype(np.float32)
+
+    ds_context = Context(meta_types=[MetaType.REAL] * data.shape[1],
+                         parametric_types=[Gaussian] * data.shape[1])
+    spn = learn_parametric(data, ds_context)
+
+    ll = log_likelihood(spn, data)
+
+    # tf_ll = eval_pytorch(spn, data)
+
+    self.assertTrue(np.all(np.isclose(ll, tf_ll)))
+
+
+if __name__ == '__main__':
+    test_eval_gaussian()

--- a/src/spn/tests/layerwise_spn.py
+++ b/src/spn/tests/layerwise_spn.py
@@ -1,82 +1,56 @@
-import unittest
-from spn.algorithms.Inference import log_likelihood
-from spn.algorithms.LearningWrappers import learn_parametric, learn_mspn
-from spn.structure.leaves.parametric.parametric import Gaussian
-from spn.structure.StatisticalTypes import MetaType
+import structure
 import numpy as np
-from spn.structure.Base import Context
-import numpy as np
-import torch
-import pdb
-import math
 from collections import defaultdict, deque
-
-# class TestPytorch(unittest.TestCase):
-
-
-def test_eval_gaussian():
-    np.random.seed(17)
-    data = np.random.normal(10, 0.01, size=2000).tolist() + \
-        np.random.normal(30, 10, size=2000).tolist()
-    data = np.array(data).reshape((-1, 10))
-    data = data.astype(np.float32)
-
-    ds_context = Context(meta_types=[MetaType.REAL] * data.shape[1],
-                         parametric_types=[Gaussian] * data.shape[1])
-    spn = learn_parametric(data, ds_context)
-    # ll = log_likelihood(spn, data)
-
-    # tf_ll = eval_pytorch(spn, data)
-    return spn
-    # self.assertTrue(np.all(np.isclose(ll, tf_ll)))
-
-
-spn = test_eval_gaussian()
 
 sum_type = "sum"
 prd_type = "prd"
 
 
 class CVMetaData(object):
-    def __init__(self, spn):
+    def __init__(self, cv):
         self.depth = 0
         self.masks_by_level = []
         self.type_by_level = []
+        self.connections_by_level = []
+        self.weight_indices_by_level = []
         self.level_label_by_node = {}
         self.num_nodes_by_level = []
         self.nodes_by_level = []
         # The input index of the i-th leaf.
         self.leaves_input_indices = []
-        self.get_cv_metadata(spn)
+        self.leaves_network_id = []
+        self.num_leaves_per_network = None
+        self.weights = cv.weights  # TODO: Make sure this is right
+        self.get_cv_metadata(cv)
 
-    def get_cv_metadata(self, spn):
+    def get_cv_metadata(self, cv):
         '''
         Returns a node labelling scheme.
         Perform a per level labelling to each node.
         Defines the order in which each node appears in the matrix.
         '''
         level = 0
-        q = deque([spn])
+        q = deque(cv.roots)
         visited = {}
         # Perform a per level traversal
         while q:
-            pdb.set_trace()
             level_size = len(q)
             curr_level = []  # nodes at the current level
             level_type = None
             for i in range(level_size):
                 node = q.popleft()
                 curr_level.append(node)
-                if isinstance(node, Leaf):
+                if isinstance(node, structure.leaf.Leaf):
                     continue
                 else:
-                    node_type = sum_type if isinstance(node, Sum) else prd_type
+                    node_type = sum_type if isinstance(node, structure.node.Sum) else prd_type
                     if level_type is None:
                         level_type = node_type
                     elif node_type != level_type:
                         error = "Level type mismatch: Expects " + level_type + " gets " + node_type
                         raise Exception(error)
-                for child in node.children:
+                for edge in node.edges:
+                    child = edge.child
                     if child in visited:
                         continue
                     visited[child] = True
@@ -93,6 +67,7 @@ class CVMetaData(object):
         self.masks_by_level = self.get_masks_by_level(cv)
         self.leaves_network_id = self.get_leaves_network_id(cv)
         self.leaves_input_indices = self.get_leaves_input_indices(cv)
+        (self.connections_by_level, self.weight_indices_by_level) = self.get_connections_and_weights_by_level(cv)
         self.num_leaves_per_network = cv.x_size * cv.y_size
 
     def get_masks_by_level(self, cv):
@@ -108,7 +83,8 @@ class CVMetaData(object):
             cur_level_nodes = self.nodes_by_level[cur_level]
             for cur_node in cur_level_nodes:
                 cur_label = self.level_label_by_node[cur_node]
-                for child_node in cur_node.children:
+                for child_edge in cur_node.edges:
+                    child_node = child_edge.child
                     child_label = self.level_label_by_node[child_node]
                     level_mask[cur_label][child_label] = 1
             level_mask = level_mask.T
@@ -131,6 +107,32 @@ class CVMetaData(object):
             leaves_network_id.append(int(leaf.network_id))
         return leaves_network_id
 
+    def get_connections_and_weights_by_level(self, cv):
+        '''
+        Returns TorchSPN style sparse connection corresponding to ConvSPN cv
+        '''
+        connections_by_level = []
+        weight_indices_by_level = []
+        for cur_level in range(self.depth - 1):
+            next_level = cur_level + 1
+            cur_level_count = self.num_nodes_by_level[cur_level]
+            next_level_count = self.num_nodes_by_level[next_level]
+            cur_level_nodes = self.nodes_by_level[cur_level]
+            level_connections = [[] for c in cur_level_nodes]
+            weights = [[] for c in cur_level_nodes]
+            level_type = cur_level_nodes[0].node_type
+            for cur_node in cur_level_nodes:
+                cur_label = self.level_label_by_node[cur_node]
+                for child_edge in cur_node.edges:
+                    child_node = child_edge.child
+                    child_label = self.level_label_by_node[child_node]
+                    level_connections[cur_label].append(child_label)
+                    if level_type == 'Sum':
+                        weights[cur_label].append(child_edge.weight_id)
+            connections_by_level.append(level_connections)
+            weight_indices_by_level.append(weights)
+        return (connections_by_level, weight_indices_by_level)
+
 
 def get_edge_count_from_layers(cv_layers):
     '''
@@ -142,4 +144,15 @@ def get_edge_count_from_layers(cv_layers):
     return edge_count
 
 
-cvm = CVMetaData(spn)
+total_edge_count = 0
+edges = []
+
+
+def get_edges(level, level_type, level_nodes, edge_count):
+    if level_type != 'Sum':
+        return
+    global edges, total_edge_count
+    for node in level_nodes:
+        level_edges = list(node.weight_id_by_child.values())
+        edges.extend(level_edges)
+    total_edge_count += edge_count

--- a/src/spn/tests/test_pytorch.py
+++ b/src/spn/tests/test_pytorch.py
@@ -1,0 +1,34 @@
+import unittest
+
+from spn.algorithms.Inference import log_likelihood
+from spn.algorithms.LearningWrappers import learn_parametric, learn_mspn
+# from spn.gpu.PyTorch import spn_to_pytorch_graph, eval_pytorch, likelihood_loss, pytorch_graph_to_spn
+from spn.structure.StatisticalTypes import MetaType
+import numpy as np
+
+from spn.structure.leaves.parametric.Parametric import Gaussian
+import torch
+
+
+class TestPytorch(unittest.Testcase):
+
+    def test_eval_gaussian(self):
+        np.random.seed(17)
+        data = np.random.normal(10, 0.01, size=2000).tolist() + \
+            np.random.normal(30, 10, size=2000).tolist()
+        data = np.array(data).reshape((-1, 10))
+        data = data.astype(np.float32)
+
+        ds_context = Context(meta_types=[MetaType.REAL] * data.shape[1],
+                             parametric_types=[Gaussian] * data.shape[1])
+        spn = learn_parametric(data, ds_context)
+
+        ll = log_likelihood(spn, data)
+
+        tf_ll = eval_pytorch(spn, data)
+
+        self.assertTrue(np.all(np.isclose(ll, tf_ll)))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Work in Progress (*please don't merge yet*)

- Added basic Edge/Node abstraction to compute the SPN layerwise
- Added basic network architecture from TorchSPN to convert the spn structure to the equivalent layerwise graph
- PyTorch base code to construct the graph
- Implementation of forward passes (init)
- Handling of the parameter space of the SPN (useful for pytorch computation, might also help in the long run in the integration with Pyro)
- Same test case as test_tensorflow

TODO:
- Get the masks by level code.
- Evaluating several SPNs and confirming the layerwise code is equivalent
- Pytorch gpu/cpu tests