### PR TITLE
Move from print to python logging

### DIFF
--- a/src/spn/algorithms/CnetStructureLearning.py
+++ b/src/spn/algorithms/CnetStructureLearning.py
@@ -7,7 +7,9 @@ Created on Ocotber 27, 2018
 import logging
 from collections import deque
 from spn.algorithms.StructureLearning import Operation, default_slicer
+import logging
 
+logger = logging.getLogger(__name__)
 try:
     from time import perf_counter
 except:

--- a/src/spn/algorithms/Condition.py
+++ b/src/spn/algorithms/Condition.py
@@ -4,6 +4,9 @@ from spn.structure.Base import Sum, Product, Leaf, get_nodes_by_type, eval_spn_b
 
 from spn.algorithms.TransformStructure import Copy, Prune
 from spn.algorithms.Inference import log_likelihood
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def prod_condition(node, children, input_vals=None, scope=None):

--- a/src/spn/algorithms/EM.py
+++ b/src/spn/algorithms/EM.py
@@ -14,6 +14,9 @@ from spn.structure.leaves.parametric.Parametric import Gaussian
 
 from spn.structure.Base import Sum, get_nodes_by_type, get_number_of_nodes
 import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def gaussian_em_update(

--- a/src/spn/algorithms/Gradient.py
+++ b/src/spn/algorithms/Gradient.py
@@ -1,5 +1,8 @@
 from spn.structure.Base import eval_spn_top_down, Sum, Product, Leaf
 import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def gradient_backward(spn, lls_per_node):

--- a/src/spn/algorithms/Inference.py
+++ b/src/spn/algorithms/Inference.py
@@ -3,10 +3,13 @@ Created on March 21, 2018
 
 @author: Alejandro Molina
 """
+import logging
 import numpy as np
 from scipy.special import logsumexp
 
-from spn.structure.Base import Product, Sum, Leaf, eval_spn_bottom_up, eval_spn_top_down
+from spn.structure.Base import Product, Sum, eval_spn_bottom_up
+
+logger = logging.getLogger(__name__)
 
 EPSILON = 0.000000000000001
 

--- a/src/spn/algorithms/LeafLearning.py
+++ b/src/spn/algorithms/LeafLearning.py
@@ -5,6 +5,9 @@ from spn.structure.Base import Leaf
 from spn.structure.leaves.histogram.Histograms import create_histogram_leaf, Histogram
 from spn.structure.leaves.parametric.Parametric import create_parametric_leaf, Parametric
 from spn.structure.leaves.piecewise.PiecewiseLinear import create_piecewise_leaf, PiecewiseLinear
+import logging
+
+logger = logging.getLogger(__name__)
 
 # from spn.structure.leaves.conditional.Conditional import create_conditional_leaf, Conditional
 

--- a/src/spn/algorithms/LearningWrappers.py
+++ b/src/spn/algorithms/LearningWrappers.py
@@ -20,6 +20,9 @@ from spn.algorithms.splitting.Conditioning import (
     get_split_rows_naive_mle_conditioning,
     get_split_rows_random_conditioning,
 )
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def learn_classifier(data, ds_context, spn_learn_wrapper, label_idx, **kwargs):

--- a/src/spn/algorithms/MPE.py
+++ b/src/spn/algorithms/MPE.py
@@ -7,6 +7,9 @@ from spn.algorithms.Inference import log_likelihood, sum_log_likelihood, prod_lo
 from spn.algorithms.Validity import is_valid
 from spn.structure.Base import Product, Sum, get_nodes_by_type, eval_spn_top_down
 import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def mpe_prod(node, parent_result, data=None, lls_per_node=None, rand_gen=None):

--- a/src/spn/algorithms/Marginalization.py
+++ b/src/spn/algorithms/Marginalization.py
@@ -8,6 +8,9 @@ from copy import deepcopy
 from spn.algorithms.TransformStructure import Prune
 from spn.algorithms.Validity import is_valid
 from spn.structure.Base import Sum, Leaf, assign_ids
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def marginalize(node, keep):

--- a/src/spn/algorithms/Posteriors.py
+++ b/src/spn/algorithms/Posteriors.py
@@ -19,6 +19,9 @@ from spn.structure.leaves.parametric.Parametric import (
     Exponential,
 )
 from spn.structure.leaves.parametric.Sampling import sample_parametric_node
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class PriorNormalInverseGamma:
@@ -203,7 +206,7 @@ def update_params_GaussianNode(node, X, rand_gen, nig_prior):
     sigma2_sam = sigma2_sam * b_n
     std_n = np.sqrt(sigma2_sam * V_n)
     mu_sam = sample_parametric_node(Gaussian(m_n, std_n), 1, None, rand_gen)
-    # print('sigm', sigma2_sam, 'std_n', std_n, 'v_n', V_n, mu_sam, m_n)
+    # logger.info('sigm', sigma2_sam, 'std_n', std_n, 'v_n', V_n, mu_sam, m_n)
 
     #
     # updating params
@@ -243,7 +246,7 @@ def update_params_GammaFixAlphaNode(node, X, rand_gen, gamma_prior):
     # if N is 0, then it would be like sampling from the prior
     # a_n = a_0 + N * alpha
     a_n = gamma_prior.a_0 + N * node.alpha
-    # print(a_n, gamma_prior.a_0, N, node.alpha)
+    # logger.info(a_n, gamma_prior.a_0, N, node.alpha)
 
     #
     # x = X[node.row_ids, node.scope]
@@ -299,10 +302,10 @@ def update_params_LogNormalFixVarNode(node, X, rand_gen, normal_prior):
     # sampling
     # TODO, optimize it with numba
     std_n = 1.0 / np.sqrt(tau_n)
-    # print('STDN', std_n, tau_n, mu_n, log_sum_x)
+    # logger.info('STDN', std_n, tau_n, mu_n, log_sum_x)
 
     mu_sam = sample_parametric_node(Gaussian(mu_n, std_n), 1, None, rand_gen)
-    # print('STDN', std_n, tau_n, mu_n, sum_x, np.log(mu_sam), mu_sam)
+    # logger.info('STDN', std_n, tau_n, mu_n, sum_x, np.log(mu_sam), mu_sam)
     #
     # updating params (only mean)
     node.mean = mu_sam[0]

--- a/src/spn/algorithms/Sampling.py
+++ b/src/spn/algorithms/Sampling.py
@@ -10,6 +10,9 @@ import numpy as np
 from spn.algorithms.Inference import log_likelihood
 from spn.algorithms.Validity import is_valid
 from spn.structure.Base import Product, Sum, get_nodes_by_type, eval_spn_top_down
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def sample_prod(node, input_vals, data=None, lls_per_node=None, rand_gen=None):

--- a/src/spn/algorithms/SamplingRange.py
+++ b/src/spn/algorithms/SamplingRange.py
@@ -9,6 +9,9 @@ import numpy as np
 
 from spn.structure.Base import Product, Sum, Leaf, get_nodes_by_type
 from spn.algorithms.Inference import _node_likelihood
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def validate_ids(node):
@@ -173,10 +176,10 @@ if __name__ == "__main__":
     samples = SamplingRange.sample_instances(
         root_node, 2, 30, rand_gen, ranges=ranges, node_sample=node_sample, node_likelihood=inference_support_ranges
     )  # , return_Zs, return_partition, dtype)
-    print("Samples: " + str(samples))
+    logger.info("Samples: " + str(samples))
 
     ranges = [NominalRange([0]), NumericRange([[3.0, 3.1], [3.5, 4.0]])]
     samples = SamplingRange.sample_instances(
         root_node, 2, 30, rand_gen, ranges=ranges, node_sample=node_sample, node_likelihood=inference_support_ranges
     )  # , return_Zs, return_partition, dtype)
-    print("Samples: " + str(samples))
+    logger.info("Samples: " + str(samples))

--- a/src/spn/algorithms/Statistics.py
+++ b/src/spn/algorithms/Statistics.py
@@ -7,6 +7,9 @@ from collections import Counter
 
 from spn.structure.Base import get_nodes_by_type, Sum, Product, Leaf, get_number_of_edges, get_depth, Node
 from spn.structure.leaves.parametric.Parametric import Parametric
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def get_structure_stats_dict(node):

--- a/src/spn/algorithms/StructureLearning.py
+++ b/src/spn/algorithms/StructureLearning.py
@@ -6,6 +6,9 @@ Created on March 20, 2018
 import logging
 from collections import deque
 from enum import Enum
+import logging
+
+logger = logging.getLogger(__name__)
 
 try:
     from time import perf_counter

--- a/src/spn/algorithms/TransformStructure.py
+++ b/src/spn/algorithms/TransformStructure.py
@@ -7,6 +7,9 @@ from copy import deepcopy
 
 from spn.algorithms.Validity import is_valid
 from spn.structure.Base import Leaf, Sum, Product, assign_ids, get_nodes_by_type, get_parents, get_topological_order
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def Compress(node):

--- a/src/spn/algorithms/Validity.py
+++ b/src/spn/algorithms/Validity.py
@@ -4,6 +4,9 @@ Created on March 20, 2018
 @author: Alejandro Molina
 """
 from spn.structure.Base import Sum, Product, get_nodes_by_type
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def is_consistent(node):

--- a/src/spn/algorithms/measures/InformationTheory.py
+++ b/src/spn/algorithms/measures/InformationTheory.py
@@ -6,6 +6,9 @@ Created on Novenber 14, 2018
 
 """
 import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def conditional_mutual_information(spn, ds_context, X, Y, cond_Z, debug=False):
@@ -31,8 +34,7 @@ def conditional_mutual_information(spn, ds_context, X, Y, cond_Z, debug=False):
     hxyz = entropy(spn, ds_context, X | Y | cond_Z, debug)
     # by definition
     cmi = hxz + hyz - hz - hxyz
-    if debug:
-        print("I(%s,%s|%s)=%s" % (X, Y, cond_Z, cmi))
+    logger.debug("I(%s,%s|%s)=%s" % (X, Y, cond_Z, cmi))
     return cmi
 
 
@@ -52,8 +54,7 @@ def mutual_information(spn, ds_context, Xset, Yset, debug=False):
     hxy = entropy(spn, ds_context, Xset | Yset, debug)
     mi = hx + hy - hxy
 
-    if debug:
-        print("I(%s)=%s" % (Xset | Yset, mi))
+    logger.debug("I(%s)=%s" % (Xset | Yset, mi))
 
     return mi
 
@@ -79,8 +80,7 @@ def entropy(spn, ds_context, RVset, debug=False):
     h[np.isnan(h)] = 0
     H = -(h.sum())
 
-    if debug:
-        print("H(%s)=%s" % (RVset, H))
+    logger.debug("H(%s)=%s" % (RVset, H))
 
     return H
 
@@ -133,7 +133,7 @@ def print_debug_info(ds_context, X, Y, cond_Z):
     y = np.array(list(Y))
     for index in c_Z:
         v4print = v4print + str(ds_context.domains[index].size) + " * "
-    print(
+    logger.info(
         "Number of permutation in CMI: n1(",
         ds_context.domains[x[0]].size,
         "), n2(",

--- a/src/spn/algorithms/measures/WeightOfEvidence.py
+++ b/src/spn/algorithms/measures/WeightOfEvidence.py
@@ -8,6 +8,9 @@ Created on Novenber 14, 2018
 import numpy as np
 
 from spn.algorithms.Inference import likelihood
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def weight_of_evidence(spn, y_index, x_instance, n, k):

--- a/src/spn/algorithms/splitting/Base.py
+++ b/src/spn/algorithms/splitting/Base.py
@@ -10,6 +10,9 @@ from networkx import from_numpy_matrix, connected_components
 from sklearn.feature_extraction.text import TfidfTransformer
 
 from spn.structure.StatisticalTypes import MetaType
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def preproc(data, ds_context, pre_proc, ohe):
@@ -88,7 +91,7 @@ def split_data_by_clusters(data, clusters, scope, rows=True):
 
 
 def split_conditional_data_by_clusters(data, clusters, scope, rows=True):
-    print(clusters)
+    logger.info(clusters)
 
     unique_clusters = np.unique(clusters)
     result = []
@@ -99,7 +102,7 @@ def split_conditional_data_by_clusters(data, clusters, scope, rows=True):
     dataOut = data[:, local_scope]
     dataIn = data[:, len(scope) :]
 
-    # print(np.shape(data), np.shape(dataOut), np.shape(dataIn))
+    # logger.info(np.shape(data), np.shape(dataOut), np.shape(dataIn))
     for uc in unique_clusters:
         if rows:
             raise NotImplementedError
@@ -107,6 +110,6 @@ def split_conditional_data_by_clusters(data, clusters, scope, rows=True):
             local_data = np.concatenate((dataOut[:, clusters == uc].reshape((data.shape[0], -1)), dataIn), axis=1)
             proportion = local_data.shape[1] / data.shape[1]
             result.append((local_data, nscope[clusters == uc].tolist(), proportion))
-            # print(uc)
-            # print('cplit cols', np.shape(data), np.shape(local_data), np.shape(dataOut[:, clusters == uc].reshape((data.shape[0], -1))), np.shape(dataIn))
+            # logger.info(uc)
+            # logger.info('cplit cols', np.shape(data), np.shape(local_data), np.shape(dataOut[:, clusters == uc].reshape((data.shape[0], -1))), np.shape(dataIn))
     return result

--- a/src/spn/algorithms/splitting/Clustering.py
+++ b/src/spn/algorithms/splitting/Clustering.py
@@ -8,7 +8,9 @@ from sklearn.cluster import KMeans, DBSCAN
 from sklearn.metrics import pairwise
 
 from spn.algorithms.splitting.Base import split_data_by_clusters, preproc
+import logging
 
+logger = logging.getLogger(__name__)
 _rpy_initialized = False
 
 
@@ -85,7 +87,7 @@ def get_split_rows_Gower(n_clusters=2, pre_proc=None, seed=17):
             clusters = np.asarray(clusters)
         except Exception as e:
             np.savetxt("/tmp/errordata.txt", local_data)
-            print(e)
+            logger.info(e)
             raise e
 
         return split_data_by_clusters(local_data, clusters, scope, rows=True)

--- a/src/spn/algorithms/splitting/Conditioning.py
+++ b/src/spn/algorithms/splitting/Conditioning.py
@@ -7,6 +7,9 @@ Created on October 26, 2018
 import numpy as np
 
 from spn.algorithms.splitting.Base import split_data_by_clusters
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def get_split_rows_random_conditioning():

--- a/src/spn/algorithms/splitting/ParametricTests.py
+++ b/src/spn/algorithms/splitting/ParametricTests.py
@@ -10,6 +10,9 @@ import numba
 from collections import deque
 
 from spn.algorithms.splitting.Base import split_data_by_clusters
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 @numba.njit
@@ -23,7 +26,7 @@ def g_test(feature_id_1, feature_id_2, local_data, feature_vals, g_factor):
     """
     Applying a G-test on the two features (represented by ids) on the data
     """
-    # print(feature_id_1, feature_id_2, instance_ids)
+    # logger.info(feature_id_1, feature_id_2, instance_ids)
 
     #
     # swap to preserve order, is this needed?
@@ -35,7 +38,7 @@ def g_test(feature_id_1, feature_id_2, local_data, feature_vals, g_factor):
         feature_id_1 = feature_id_2
         feature_id_2 = tmp
 
-    # print(feature_id_1, feature_id_2, instance_ids)
+    # logger.info(feature_id_1, feature_id_2, instance_ids)
 
     # n_instances = len(instance_ids)
     n_instances = len(local_data)
@@ -54,7 +57,7 @@ def g_test(feature_id_1, feature_id_2, local_data, feature_vals, g_factor):
     for i in range(n_instances):
         co_occ_matrix[local_data[i, feature_id_1], local_data[i, feature_id_2]] += 1
 
-    # print('Co occurrences', co_occ_matrix)
+    # logger.info('Co occurrences', co_occ_matrix)
     #
     # getting the sum for each feature
     for i in range(feature_size_1):
@@ -63,7 +66,7 @@ def g_test(feature_id_1, feature_id_2, local_data, feature_vals, g_factor):
             feature_tot_1[i] += count
             feature_tot_2[j] += count
 
-    # print('Feature tots', feature_tot_1, feature_tot_2)
+    # logger.info('Feature tots', feature_tot_1, feature_tot_2)
 
     #
     # counputing the number of zero total co-occurrences for the degree of
@@ -121,7 +124,7 @@ def gtest_greedy_feature_split(local_data, feature_vals, g_factor, rand_gen):
         for other_feature_id in feature_ids_mask.nonzero()[0]:
 
             #
-            # print('considering other features', other_feature_id)
+            # logger.info('considering other features', other_feature_id)
             # feature_id_2 = data_slice.feature_ids[other_feature_id]
             #
             # apply a G-test

--- a/src/spn/algorithms/splitting/PoissonStabilityTest.py
+++ b/src/spn/algorithms/splitting/PoissonStabilityTest.py
@@ -19,7 +19,9 @@ from scipy.stats._continuous_distns import chi2
 
 from spn.algorithms.splitting.Base import split_data_by_clusters
 from spn.structure.leaves.parametric.Parametric import Poisson
+import logging
 
+logger = logging.getLogger(__name__)
 beta = numpy.asarray(
     [
         -0.0648467,
@@ -3028,7 +3030,7 @@ beta = numpy.asarray(
 
 def chi2cdf(x, k):
     x, k = mpmath.mpf(x), mpmath.mpf(k)
-    # print(x,k)
+    # logger.info(x,k)
     return mpmath.gammainc(k / 2.0, 0.0, x / 2.0, regularized=True)
 
 
@@ -3036,7 +3038,7 @@ def logchi2sf(x, k):
     res = chi2.logsf(x, k)
     for ix in numpy.where(res == NINF)[0]:
         res[ix] = float(mpmath.log(1.0 - chi2cdf(x[ix], k[ix])))
-    # print(res)
+    # logger.info(res)
     # if res == NINF:
     #    res = float(mpmath.log(1.0-chi2cdf(x,k)))
 
@@ -3044,7 +3046,7 @@ def logchi2sf(x, k):
 
 
 def supLM(x, k, lambda_):
-    # print(x, k, lambda_)
+    # logger.info(x, k, lambda_)
     nb = beta.shape[1] - 1
 
     tau = lambda_
@@ -3059,7 +3061,7 @@ def supLM(x, k, lambda_):
 
     # pp = chi2.logsf(dummy, beta_[:,nb])
     pp = logchi2sf(dummy, beta_[:, nb])
-    # print(pp)
+    # logger.info(pp)
 
     if tau == 0.5:
         p = numpy.log(1 - chi2.cdf(x, k))
@@ -3103,7 +3105,7 @@ def computeEstabilityTest(df, yv):
 
     process = J12 * process
 
-    # print(sum(abs(process)))
+    # logger.info(sum(abs(process)))
 
     from_ = numpy.ceil(n * 0.1)
     from_ = int(max(from_, 10))
@@ -3137,11 +3139,11 @@ def computeEstabilityTest(df, yv):
         xx = xx[from_ - 1 : to]
         stati = numpy.max(xx / ttt)
 
-        # print(stati, k, lambda_)
+        # logger.info(stati, k, lambda_)
         pvals[zv] = supLM(stati, k, lambda_)
-        # print(pvals[zv])
+        # logger.info(pvals[zv])
 
-    # print(pvals)
+    # logger.info(pvals)
 
     return numpy.exp(pvals)
 

--- a/src/spn/algorithms/splitting/RDC.py
+++ b/src/spn/algorithms/splitting/RDC.py
@@ -295,7 +295,7 @@ def getIndependentRDCGroups_py(
     #
     # thresholding
     rdc_adjacency_matrix[rdc_adjacency_matrix < threshold] = 0
-    # logger.info("thresholding", rdc_adjacency_matrix)
+    # logger.info("thresholding %s", rdc_adjacency_matrix)
 
     #
     # getting connected components

--- a/src/spn/algorithms/splitting/RDC.py
+++ b/src/spn/algorithms/splitting/RDC.py
@@ -8,7 +8,9 @@ import numpy as np
 from sklearn.cluster import KMeans
 
 from spn.algorithms.splitting.Base import split_data_by_clusters, clusters_by_adjacency_matrix
+import logging
 
+logger = logging.getLogger(__name__)
 _rpy_initialized = False
 
 
@@ -48,7 +50,7 @@ def get_RDC_transform(data, meta_types, ohe=False, k=10, s=1 / 6):
         out = np.asarray(out)
     except Exception as e:
         np.savetxt("/tmp/errordata.txt", data)
-        print(e)
+        logger.info(e)
         raise e
 
     return out
@@ -69,7 +71,7 @@ def get_RDC_adjacency_matrix(data, meta_types, ohe=False, linear=True):
         out = np.asarray(out)
     except Exception as e:
         np.savetxt("/tmp/errordata.txt", data)
-        print(e)
+        logger.info(e)
         raise e
 
     return out
@@ -174,7 +176,7 @@ def rdc_transformer(
     ohe=True,
     rand_gen=None,
 ):
-    # print('rdc transformer', k, s, non_linearity)
+    # logger.info('rdc transformer', k, s, non_linearity)
     """
     Given a data_slice,
     return a transformation of the features data in it according to the rdc
@@ -245,7 +247,7 @@ def rdc_cca(indexes):
     cca = CCA(n_components=1, max_iter=CCA_MAX_ITER)
     X_cca, Y_cca = cca.fit_transform(rdc_features[i], rdc_features[j])
     rdc = np.corrcoef(X_cca.T, Y_cca.T)[0, 1]
-    # print(i, j, rdc)
+    # logger.info(i, j, rdc)
     return rdc
 
 
@@ -293,7 +295,7 @@ def getIndependentRDCGroups_py(
     #
     # thresholding
     rdc_adjacency_matrix[rdc_adjacency_matrix < threshold] = 0
-    # print("thresholding", rdc_adjacency_matrix)
+    # logger.info("thresholding", rdc_adjacency_matrix)
 
     #
     # getting connected components

--- a/src/spn/algorithms/splitting/Random.py
+++ b/src/spn/algorithms/splitting/Random.py
@@ -7,6 +7,9 @@ Created on March 20, 2018
 import numpy as np
 
 from spn.algorithms.splitting.Base import split_data_by_clusters, preproc
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def make_planes(N, dim, rand_gen):
@@ -63,13 +66,13 @@ def get_split_cols_binary_random_partition(threshold, rand_gen, beta_a=4, beta_b
         # with a certain percentage it may fail, such that row partitioning may happen
         clusters = None
         p = rand_gen.rand()
-        # print('P', p)
+        # logger.info('P', p)
         if p > threshold:
             #
             # draw percentage of split from  a Beta
             alloc_perc = rand_gen.beta(a=beta_a, b=beta_b)
             clusters = rand_gen.choice(2, size=local_data.shape[1], p=[alloc_perc, 1 - alloc_perc])
-            # print(clusters, clusters.sum(), clusters.shape, alloc_perc)
+            # logger.info(clusters, clusters.sum(), clusters.shape, alloc_perc)
         else:
             clusters = np.zeros(local_data.shape[1])
 

--- a/src/spn/algorithms/stats/Expectations.py
+++ b/src/spn/algorithms/stats/Expectations.py
@@ -3,6 +3,9 @@
 @author Claas Völcker
 """
 from spn.algorithms.stats.Moments import Moment, ConditionalMoment, _node_moment
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def Expectation(spn, feature_scope=None, evidence=None):

--- a/src/spn/algorithms/stats/Moments.py
+++ b/src/spn/algorithms/stats/Moments.py
@@ -4,7 +4,9 @@ from spn.algorithms.Condition import condition
 from spn.algorithms.Inference import _node_likelihood
 from spn.algorithms.Marginalization import marginalize
 from spn.structure.Base import Sum, Product, eval_spn_bottom_up, Leaf, get_node_types
+import logging
 
+logger = logging.getLogger(__name__)
 _node_moment = {}
 
 

--- a/src/spn/data/datasets.py
+++ b/src/spn/data/datasets.py
@@ -12,6 +12,9 @@ import arff
 from scipy.io.arff import loadarff
 import pandas as pd
 import xml.etree.ElementTree as ET
+import logging
+
+logger = logging.getLogger(__name__)
 
 path = dirname(__file__) + "/"
 

--- a/src/spn/gpu/TensorFlow.py
+++ b/src/spn/gpu/TensorFlow.py
@@ -13,6 +13,9 @@ from spn.structure.Base import Product, Sum, eval_spn_bottom_up
 from spn.structure.leaves.histogram.Histograms import Histogram
 from spn.structure.leaves.histogram.Inference import histogram_likelihood
 from spn.structure.leaves.parametric.Parametric import Gaussian
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def log_sum_to_tf_graph(node, children, data_placeholder=None, variable_dict=None, log_space=True, dtype=np.float32):
@@ -118,7 +121,7 @@ def optimize_tf_graph(tf_graph, variable_dict, data_placeholder, data, epochs=10
             for j in range(batches_per_epoch):
                 data_batch = data[j * batch_size : (j + 1) * batch_size, :]
                 _, cur_loss = sess.run([opt_op, loss], feed_dict={data_placeholder: data_batch})
-            print("epoch: {}, loss: {}".format(i, cur_loss))
+            logger.info("epoch: {}, loss: {}".format(i, cur_loss))
         tf_graph_to_spn(variable_dict)
 
 
@@ -155,7 +158,7 @@ def eval_tf_trace(spn, data, log_space=True, save_graph_path=None):
 
         e2 = end - start
 
-        print(e2)
+        logger.info(e2)
 
         tl = timeline.Timeline(run_metadata.step_stats)
         ctf = tl.generate_chrome_trace_format()

--- a/src/spn/gpu/cuda.py
+++ b/src/spn/gpu/cuda.py
@@ -18,6 +18,9 @@ from spn.structure.Base import Sum, get_nodes_by_type, Leaf, Product
 from spn.structure.leaves.parametric.Inference import add_parametric_inference_support
 from spn.structure.leaves.parametric.Parametric import Gaussian
 import math
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def get_execution_layers(spn):
@@ -151,64 +154,64 @@ if __name__ == "__main__":
         rg.random_split(2, 2)
 
     rg_layers = rg.make_layers()
-    print("random graph built in  ", (time.perf_counter() - start))
+    logger.info("random graph built in  ", (time.perf_counter() - start))
 
     start = time.perf_counter()
     vector_list, root = Make_SPN_from_RegionGraph(
         rg_layers, np.random.RandomState(100), num_classes=1, num_gauss=20, num_sums=20
     )
-    print("Make_SPN_from_RegionGraph in  ", (time.perf_counter() - start))
+    logger.info("Make_SPN_from_RegionGraph in  ", (time.perf_counter() - start))
 
     start = time.perf_counter()
-    print(get_structure_stats(root))
-    print("get_structure_stats in  ", (time.perf_counter() - start))
+    logger.info(get_structure_stats(root))
+    logger.info("get_structure_stats in  ", (time.perf_counter() - start))
 
     old_root = Copy(root)
 
     start = time.perf_counter()
     root = Prune(root)
-    print("Prune in  ", (time.perf_counter() - start))
+    logger.info("Prune in  ", (time.perf_counter() - start))
 
     start = time.perf_counter()
     root = SPN_Reshape(root, 2)
-    print("SPN_Reshape in  ", (time.perf_counter() - start))
+    logger.info("SPN_Reshape in  ", (time.perf_counter() - start))
 
     start = time.perf_counter()
-    print(get_structure_stats(root))
-    print("get_structure_stats in  ", (time.perf_counter() - start))
+    logger.info(get_structure_stats(root))
+    logger.info("get_structure_stats in  ", (time.perf_counter() - start))
 
     start = time.perf_counter()
     layers, layer_types = get_execution_layers(root)
-    print("get_execution_layers in  ", (time.perf_counter() - start))
+    logger.info("get_execution_layers in  ", (time.perf_counter() - start))
 
     for i, lt in enumerate(layer_types):
-        print(lt, len(layers[i]))
+        logger.info(lt, len(layers[i]))
 
     max_id = max(map(lambda n: n.id, get_nodes_by_type(root)))
-    print(max_id)
+    logger.info(max_id)
 
     children_sizes = list(map(lambda n: len(n.children), get_nodes_by_type(root, Sum)))
-    print("cs ", np.unique(children_sizes, return_counts=True))
+    logger.info("cs ", np.unique(children_sizes, return_counts=True))
     params = sum(children_sizes)
     params += 2 * len(get_nodes_by_type(root, Leaf))
 
     start = time.perf_counter()
     params = get_parameters(root)
-    print("get_parameters in  ", (time.perf_counter() - start))
+    logger.info("get_parameters in  ", (time.perf_counter() - start))
 
-    print(params)
+    logger.info(params)
     LL = np.zeros((100, params.shape[1]))
     X = np.random.randn(LL.shape[0] * LL.shape[1]).reshape((LL.shape[0], -1))
 
     lls_matrix = np.zeros_like(LL)
 
-    print("LL size", lls_matrix.shape)
+    logger.info("LL size", lls_matrix.shape)
 
-    print(" number of nodes ", len(get_nodes_by_type(root)))
+    logger.info(" number of nodes ", len(get_nodes_by_type(root)))
 
     start = time.perf_counter()
     log_likelihood(root, X, lls_matrix=lls_matrix)
-    print("it took in python ", (time.perf_counter() - start))
+    logger.info("it took in python ", (time.perf_counter() - start))
 
     start = time.perf_counter()
 
@@ -217,9 +220,9 @@ if __name__ == "__main__":
     d_X = cuda.to_device(X)
 
     for i, lt in enumerate(layer_types):
-        # print(lt, len(layers[i]))
+        # logger.info(lt, len(layers[i]))
         node_ids = layers[i]
-        # print(node_ids)
+        # logger.info(node_ids)
 
         # instance_pos, node_pos
         threadsperblock = (32, 32)
@@ -234,14 +237,14 @@ if __name__ == "__main__":
         else:
             Sum_cuda[blockspergrid, threadsperblock](d_LL, d_params, node_ids)
 
-        # print(np.isclose(LL[:, node_ids], lls_matrix[:, node_ids]).all())
-        # print("LL")
-        # print(LL[:, node_ids])
-        # print("pll")
-        # print(lls_matrix[:, node_ids])
+        # logger.info(np.isclose(LL[:, node_ids], lls_matrix[:, node_ids]).all())
+        # logger.info("LL")
+        # logger.info(LL[:, node_ids])
+        # logger.info("pll")
+        # logger.info(lls_matrix[:, node_ids])
     d_LL.copy_to_host(LL)
     d_params.copy_to_host(params)
 
     end = time.perf_counter()
-    print(np.isclose(LL, lls_matrix).all())
-    print("it took in cuda ", (end - start))
+    logger.info(np.isclose(LL, lls_matrix).all())
+    logger.info("it took in cuda ", (end - start))

--- a/src/spn/gpu/cuda.py
+++ b/src/spn/gpu/cuda.py
@@ -154,35 +154,35 @@ if __name__ == "__main__":
         rg.random_split(2, 2)
 
     rg_layers = rg.make_layers()
-    logger.info("random graph built in  ", (time.perf_counter() - start))
+    logger.info("random graph built in %s", (time.perf_counter() - start))
 
     start = time.perf_counter()
     vector_list, root = Make_SPN_from_RegionGraph(
         rg_layers, np.random.RandomState(100), num_classes=1, num_gauss=20, num_sums=20
     )
-    logger.info("Make_SPN_from_RegionGraph in  ", (time.perf_counter() - start))
+    logger.info("Make_SPN_from_RegionGraph in  %s", (time.perf_counter() - start))
 
     start = time.perf_counter()
     logger.info(get_structure_stats(root))
-    logger.info("get_structure_stats in  ", (time.perf_counter() - start))
+    logger.info("get_structure_stats in  %s", (time.perf_counter() - start))
 
     old_root = Copy(root)
 
     start = time.perf_counter()
     root = Prune(root)
-    logger.info("Prune in  ", (time.perf_counter() - start))
+    logger.info("Prune in  %s", (time.perf_counter() - start))
 
     start = time.perf_counter()
     root = SPN_Reshape(root, 2)
-    logger.info("SPN_Reshape in  ", (time.perf_counter() - start))
+    logger.info("SPN_Reshape in  %s", (time.perf_counter() - start))
 
     start = time.perf_counter()
     logger.info(get_structure_stats(root))
-    logger.info("get_structure_stats in  ", (time.perf_counter() - start))
+    logger.info("get_structure_stats in  %s", (time.perf_counter() - start))
 
     start = time.perf_counter()
     layers, layer_types = get_execution_layers(root)
-    logger.info("get_execution_layers in  ", (time.perf_counter() - start))
+    logger.info("get_execution_layers in  %s", (time.perf_counter() - start))
 
     for i, lt in enumerate(layer_types):
         logger.info(lt, len(layers[i]))
@@ -191,13 +191,13 @@ if __name__ == "__main__":
     logger.info(max_id)
 
     children_sizes = list(map(lambda n: len(n.children), get_nodes_by_type(root, Sum)))
-    logger.info("cs ", np.unique(children_sizes, return_counts=True))
+    logger.info("cs %s", np.unique(children_sizes, return_counts=True))
     params = sum(children_sizes)
     params += 2 * len(get_nodes_by_type(root, Leaf))
 
     start = time.perf_counter()
     params = get_parameters(root)
-    logger.info("get_parameters in  ", (time.perf_counter() - start))
+    logger.info("get_parameters in  %s", (time.perf_counter() - start))
 
     logger.info(params)
     LL = np.zeros((100, params.shape[1]))
@@ -205,13 +205,13 @@ if __name__ == "__main__":
 
     lls_matrix = np.zeros_like(LL)
 
-    logger.info("LL size", lls_matrix.shape)
+    logger.info("LL size %s", lls_matrix.shape)
 
-    logger.info(" number of nodes ", len(get_nodes_by_type(root)))
+    logger.info(" number of nodes %s", len(get_nodes_by_type(root)))
 
     start = time.perf_counter()
     log_likelihood(root, X, lls_matrix=lls_matrix)
-    logger.info("it took in python ", (time.perf_counter() - start))
+    logger.info("it took in python %s", (time.perf_counter() - start))
 
     start = time.perf_counter()
 
@@ -247,4 +247,4 @@ if __name__ == "__main__":
 
     end = time.perf_counter()
     logger.info(np.isclose(LL, lls_matrix).all())
-    logger.info("it took in cuda ", (end - start))
+    logger.info("it took in cuda %s", (end - start))

--- a/src/spn/io/CPP.py
+++ b/src/spn/io/CPP.py
@@ -10,6 +10,9 @@ from spn.io.Text import spn_to_str_equation
 from spn.structure.Base import get_nodes_by_type, Leaf, eval_spn_bottom_up, Sum, Product
 from spn.structure.leaves.parametric.Parametric import Gaussian
 import math
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def to_cpp(node, c_data_type="double"):
@@ -116,7 +119,7 @@ def get_cpp_function(node):
     import cppyy
 
     cppyy.cppdef(c_code)
-    # print(c_code)
+    # logger.info(c_code)
     from cppyy.gbl import spn_many
 
     import numpy as np

--- a/src/spn/io/Graphics.py
+++ b/src/spn/io/Graphics.py
@@ -8,6 +8,9 @@ from networkx.drawing.nx_agraph import graphviz_layout
 
 # import matplotlib
 # matplotlib.use('Agg')
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def get_networkx_obj(spn):
@@ -16,7 +19,7 @@ def get_networkx_obj(spn):
     import numpy as np
 
     all_nodes = get_nodes_by_type(spn)
-    print(all_nodes)
+    logger.info(all_nodes)
 
     g = nx.Graph()
 

--- a/src/spn/io/Python.py
+++ b/src/spn/io/Python.py
@@ -4,6 +4,9 @@ Created on March 22, 2018
 @author: Alejandro Molina
 """
 import dill as pickle
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def dump_python_evaluator(node, leaf_ll):

--- a/src/spn/io/Symbolic.py
+++ b/src/spn/io/Symbolic.py
@@ -8,6 +8,9 @@ from functools import reduce
 import sympy as sp
 
 from spn.structure.Base import Sum, Product, eval_spn_bottom_up
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def prod_to_sympy(node, children, input_vars=None, log=False):

--- a/src/spn/io/Text.py
+++ b/src/spn/io/Text.py
@@ -10,6 +10,9 @@ from enum import Enum
 from spn.algorithms.Validity import is_valid
 from spn.structure.Base import Product, Sum, rebuild_scopes_bottom_up, assign_ids, Leaf
 import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def json_default(obj):
@@ -135,7 +138,7 @@ sumnode: "(" [NUMBERS "*" node ("+" NUMBERS "*" node)*] ")"
     )
 
     parser = Lark(grammar, start="node")
-    # print(grammar)
+    # logger.info(grammar)
     tree = parser.parse(text)
 
     def tree_to_spn(tree, features):

--- a/src/spn/io/plot/TreeVisualization.py
+++ b/src/spn/io/plot/TreeVisualization.py
@@ -4,6 +4,9 @@ from spn.io.Text import spn_to_str_equation
 from spn.structure.Base import Sum, Leaf, Product
 
 _symbols = {Sum: "Σ", Product: "Π"}
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def set_symbol(node_type, symbol):

--- a/src/spn/structure/Base.py
+++ b/src/spn/structure/Base.py
@@ -6,6 +6,9 @@ Created on March 20, 2018
 import numpy as np
 import collections
 from collections import deque, OrderedDict
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class Node(object):

--- a/src/spn/structure/StatisticalTypes.py
+++ b/src/spn/structure/StatisticalTypes.py
@@ -4,6 +4,9 @@ Created on April 15, 2018
 @author: Alejandro Molina
 """
 from enum import Enum
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class MetaType(Enum):

--- a/src/spn/structure/leaves/cltree/CLTree.py
+++ b/src/spn/structure/leaves/cltree/CLTree.py
@@ -5,6 +5,9 @@ Created on Ocotber 19, 2018
 
 from spn.structure.Base import Leaf
 from spn.structure.StatisticalTypes import Type
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class CLTree(Leaf):

--- a/src/spn/structure/leaves/cltree/Expectation.py
+++ b/src/spn/structure/leaves/cltree/Expectation.py
@@ -5,6 +5,9 @@ Created on October 18, 2018
 """
 from spn.algorithms.stats.Moments import add_node_moment
 from spn.structure.leaves.cltree.CLTree import *
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def cltree_expectation(node, order=1):

--- a/src/spn/structure/leaves/cltree/Inference.py
+++ b/src/spn/structure/leaves/cltree/Inference.py
@@ -8,6 +8,9 @@ from spn.algorithms.Inference import add_node_likelihood
 from spn.structure.leaves.cltree.CLTree import CLTree
 
 import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def cltree_likelihood(node, data=None, dtype=np.float64):

--- a/src/spn/structure/leaves/cltree/MLE.py
+++ b/src/spn/structure/leaves/cltree/MLE.py
@@ -9,6 +9,9 @@ from spn.structure.leaves.cltree.CLTree import CLTree
 from scipy.sparse.csgraph import minimum_spanning_tree
 from scipy.sparse.csgraph import depth_first_order
 import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def compute_cooccurences(data, C, NZ, r, c):

--- a/src/spn/structure/leaves/cltree/MPE.py
+++ b/src/spn/structure/leaves/cltree/MPE.py
@@ -8,6 +8,9 @@ from spn.structure.leaves.cltree.Inference import cltree_likelihood
 from spn.structure.leaves.cltree.CLTree import CLTree
 
 import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def cltree_bottom_up_ll(node, data, dtype=np.float64):

--- a/src/spn/structure/leaves/cltree/Sampling.py
+++ b/src/spn/structure/leaves/cltree/Sampling.py
@@ -6,6 +6,9 @@ Created on October 22, 2018
 """
 from spn.algorithms.Sampling import add_leaf_sampling
 from spn.structure.leaves.cltree.CLTree import CLTree
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def sample_cltree_node(node, n_samples, data, rand_gen):

--- a/src/spn/structure/leaves/cltree/Text.py
+++ b/src/spn/structure/leaves/cltree/Text.py
@@ -10,6 +10,9 @@ import inspect
 import numpy as np
 
 from spn.structure.leaves.cltree.CLTree import CLTree
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def cltree_to_str(node, feature_names=None, node_to_str=None):

--- a/src/spn/structure/leaves/histogram/Gradients.py
+++ b/src/spn/structure/leaves/histogram/Gradients.py
@@ -4,6 +4,9 @@ import numpy as np
 
 from spn.structure.leaves.histogram.Histograms import Histogram
 from spn.structure.leaves.histogram.Inference import histogram_ll
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def histogramm_gradient(node, input_vals=None, dtype=np.float64):

--- a/src/spn/structure/leaves/histogram/Histograms.py
+++ b/src/spn/structure/leaves/histogram/Histograms.py
@@ -9,7 +9,9 @@ import numpy as np
 
 from spn.structure.Base import Leaf
 from spn.structure.StatisticalTypes import MetaType, Type
+import logging
 
+logger = logging.getLogger(__name__)
 rpy_initialized = False
 
 

--- a/src/spn/structure/leaves/histogram/Inference.py
+++ b/src/spn/structure/leaves/histogram/Inference.py
@@ -11,6 +11,9 @@ from spn.structure.leaves.histogram.Histograms import Histogram
 
 # from numba import jit
 import bisect
+import logging
+
+logger = logging.getLogger(__name__)
 
 # @jit("float64[:](float64[:], float64[:], float64[:,:])", nopython=True)
 def histogram_ll(breaks, densities, data):

--- a/src/spn/structure/leaves/histogram/MPE.py
+++ b/src/spn/structure/leaves/histogram/MPE.py
@@ -8,6 +8,9 @@ import numpy as np
 from spn.algorithms.MPE import get_mpe_top_down_leaf, add_node_mpe
 from spn.structure.leaves.histogram.Histograms import Histogram
 from spn.structure.leaves.histogram.Inference import histogram_likelihood
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def histogram_mode(node):

--- a/src/spn/structure/leaves/histogram/Moment.py
+++ b/src/spn/structure/leaves/histogram/Moment.py
@@ -10,6 +10,9 @@ import numpy as np
 from spn.algorithms.stats.Moments import add_node_moment
 from spn.structure.StatisticalTypes import MetaType
 from spn.structure.leaves.histogram.Histograms import Histogram
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def histogram_moment(node, order=1):

--- a/src/spn/structure/leaves/histogram/Text.py
+++ b/src/spn/structure/leaves/histogram/Text.py
@@ -10,6 +10,9 @@ import inspect
 import numpy as np
 
 from spn.structure.leaves.histogram.Histograms import Histogram
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def histogram_to_str(node, feature_names=None, node_to_str=None):

--- a/src/spn/structure/leaves/parametric/Inference.py
+++ b/src/spn/structure/leaves/parametric/Inference.py
@@ -8,6 +8,9 @@ Created on April 15, 2018
 from spn.algorithms.Inference import add_node_likelihood, leaf_marginalized_likelihood
 from spn.structure.leaves.parametric.Parametric import *
 from spn.structure.leaves.parametric.utils import get_scipy_obj_params
+import logging
+
+logger = logging.getLogger(__name__)
 
 POS_EPS = 1e-7
 

--- a/src/spn/structure/leaves/parametric/InferenceRange.py
+++ b/src/spn/structure/leaves/parametric/InferenceRange.py
@@ -8,6 +8,9 @@ import numpy as np
 
 from spn.algorithms.Inference import add_node_likelihood
 from spn.structure.leaves.parametric.Parametric import Categorical
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def categorical_likelihood_range(node, ranges, dtype=np.float64, **kwargs):

--- a/src/spn/structure/leaves/parametric/MLE.py
+++ b/src/spn/structure/leaves/parametric/MLE.py
@@ -18,6 +18,9 @@ from spn.structure.leaves.parametric.Parametric import (
     Bernoulli,
     CategoricalDictionary,
 )
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def update_parametric_parameters_mle(node, data):

--- a/src/spn/structure/leaves/parametric/MPE.py
+++ b/src/spn/structure/leaves/parametric/MPE.py
@@ -29,6 +29,9 @@ from spn.structure.leaves.parametric.Parametric import (
     Hypergeometric,
 )
 import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def get_parametric_bottom_up_ll(ll_func, mode_func):

--- a/src/spn/structure/leaves/parametric/Moment.py
+++ b/src/spn/structure/leaves/parametric/Moment.py
@@ -6,6 +6,9 @@ Created on April 15, 2018
 from spn.algorithms.stats.Moments import add_node_moment
 from spn.structure.leaves.parametric.Parametric import *
 import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def parametric_moment(node, order=1):

--- a/src/spn/structure/leaves/parametric/Parametric.py
+++ b/src/spn/structure/leaves/parametric/Parametric.py
@@ -8,6 +8,9 @@ import numpy as np
 
 from spn.structure.Base import Leaf
 from spn.structure.StatisticalTypes import Type
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class Parametric(Leaf):

--- a/src/spn/structure/leaves/parametric/Sampling.py
+++ b/src/spn/structure/leaves/parametric/Sampling.py
@@ -20,6 +20,9 @@ from spn.structure.leaves.parametric.Parametric import (
 import numpy as np
 
 from spn.structure.leaves.parametric.utils import get_scipy_obj_params
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def sample_parametric_node(node, n_samples, data, rand_gen):

--- a/src/spn/structure/leaves/parametric/SamplingRange.py
+++ b/src/spn/structure/leaves/parametric/SamplingRange.py
@@ -8,6 +8,9 @@ import numpy as np
 
 from spn.experiments.AQP.Ranges import NominalRange
 from spn.structure.leaves.parametric.Parametric import Categorical
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def sample_categorical_node(node, n_samples, rand_gen, ranges=None):

--- a/src/spn/structure/leaves/parametric/Symbolic.py
+++ b/src/spn/structure/leaves/parametric/Symbolic.py
@@ -8,6 +8,9 @@ import sympy as sp
 from spn.structure.leaves.parametric.Parametric import *
 
 from spn.io.Symbolic import add_node_to_sympy
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def get_density(dist, node, input_vars):

--- a/src/spn/structure/leaves/parametric/Tensorflow.py
+++ b/src/spn/structure/leaves/parametric/Tensorflow.py
@@ -17,6 +17,9 @@ from spn.structure.leaves.parametric.Parametric import (
     Bernoulli,
 )
 import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def gaussian_to_tf_graph(node, data_placeholder=None, log_space=True, variable_dict=None, dtype=np.float32):

--- a/src/spn/structure/leaves/parametric/Text.py
+++ b/src/spn/structure/leaves/parametric/Text.py
@@ -8,6 +8,9 @@ from collections import OrderedDict
 import inspect
 
 from spn.structure.leaves.parametric.Parametric import Parametric, Categorical
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def parametric_to_str(node, feature_names=None, node_to_str=None):

--- a/src/spn/structure/leaves/parametric/utils.py
+++ b/src/spn/structure/leaves/parametric/utils.py
@@ -6,6 +6,9 @@ Created on April 29, 2018
 from scipy.stats import *
 
 from spn.structure.leaves.parametric.Parametric import *
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def get_scipy_obj(param_type):

--- a/src/spn/structure/leaves/piecewise/Gradients.py
+++ b/src/spn/structure/leaves/piecewise/Gradients.py
@@ -2,6 +2,9 @@ import numpy as np
 
 
 from spn.structure.leaves.piecewise.PiecewiseLinear import PiecewiseLinear
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def expand(array, left, right):

--- a/src/spn/structure/leaves/piecewise/Inference.py
+++ b/src/spn/structure/leaves/piecewise/Inference.py
@@ -9,6 +9,9 @@ import numpy as np
 
 from spn.algorithms.Inference import EPSILON, add_node_likelihood, add_node_mpe_likelihood, leaf_marginalized_likelihood
 from spn.structure.leaves.piecewise.PiecewiseLinear import PiecewiseLinear
+import logging
+
+logger = logging.getLogger(__name__)
 
 LOG_ZERO = -300
 

--- a/src/spn/structure/leaves/piecewise/InferenceRange.py
+++ b/src/spn/structure/leaves/piecewise/InferenceRange.py
@@ -8,6 +8,9 @@ import numpy as np
 
 from spn.algorithms.Inference import add_node_likelihood
 from spn.structure.leaves.piecewise.PiecewiseLinear import PiecewiseLinear
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def piecewise_likelihood_range(node, ranges, dtype=np.float64, **kwargs):

--- a/src/spn/structure/leaves/piecewise/MPE.py
+++ b/src/spn/structure/leaves/piecewise/MPE.py
@@ -9,6 +9,9 @@ import numpy as np
 from spn.algorithms.MPE import get_mpe_top_down_leaf, add_node_mpe
 from spn.structure.leaves.piecewise.PiecewiseLinear import PiecewiseLinear
 from spn.structure.leaves.piecewise.Inference import piecewise_likelihood
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def piecewise_mode(node):

--- a/src/spn/structure/leaves/piecewise/Moment.py
+++ b/src/spn/structure/leaves/piecewise/Moment.py
@@ -8,6 +8,9 @@ import numpy as np
 
 from spn.algorithms.stats.Moments import add_node_moment
 from spn.structure.leaves.piecewise.PiecewiseLinear import PiecewiseLinear
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def piecewise_moment(node, order=1):

--- a/src/spn/structure/leaves/piecewise/PiecewiseLinear.py
+++ b/src/spn/structure/leaves/piecewise/PiecewiseLinear.py
@@ -12,6 +12,9 @@ from spn.structure.Base import Leaf
 from spn.structure.StatisticalTypes import MetaType, Type
 from spn.structure.leaves.histogram.Histograms import create_histogram_leaf
 import itertools
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class PiecewiseLinear(Leaf):

--- a/src/spn/structure/leaves/piecewise/SamplingRange.py
+++ b/src/spn/structure/leaves/piecewise/SamplingRange.py
@@ -10,6 +10,9 @@ import numpy as np
 from spn.structure.leaves.piecewise.PiecewiseLinear import PiecewiseLinear
 
 from spn.experiments.AQP.Ranges import NumericRange
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def sample_piecewise_node(node, n_samples, rand_gen, ranges=None):

--- a/src/spn/structure/leaves/piecewise/Text.py
+++ b/src/spn/structure/leaves/piecewise/Text.py
@@ -7,6 +7,9 @@ from spn.io.Text import add_str_to_spn, add_node_to_str
 
 from spn.structure.leaves.histogram.Histograms import Histogram
 from spn.structure.leaves.piecewise.PiecewiseLinear import PiecewiseLinear
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def piecewise_to_str(node, feature_names=None, node_to_str=None):


### PR DESCRIPTION
Replace print statements with Python's logging module for advanced and flexible logging, following Python best practices. 

With this, logging can be set up on a per-user basis. An example would be the default stdout logging:
```python
logging.basicConfig(
    level=logging.INFO,
    handlers=[logging.StreamHandler(stream=sys.stdout)],
    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
)
```
 which then produces logs like the following (in the case of calling `optimize_tf(..)`:
```
2018-12-15 15:30:17,744 - spn.gpu.TensorFlow - INFO - epoch: 0, loss: 7.72321
2018-12-15 15:30:17,745 - spn.gpu.TensorFlow - INFO - epoch: 1, loss: 7.66431
2018-12-15 15:30:17,746 - spn.gpu.TensorFlow - INFO - epoch: 2, loss: 7.62131
...
```

See also the Python documentation: 
- [Advanced Logging Tutorial](https://docs.python.org/3/howto/logging.html#advanced-logging-tutorial)
- [Configuring Logging for a Library](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library)