### PR TITLE
Fix MPE bottom-up mixing log-likelihoods with likelihoods (Gaussian & Categoricals)

### DIFF
--- a/src/spn/algorithms/Inference.py
+++ b/src/spn/algorithms/Inference.py
@@ -73,13 +73,6 @@ def add_node_likelihood(node_type, lambda_func, log_lambda_func=None):
     _node_log_likelihood[node_type] = log_lambda_func
 
 
-_node_mpe_likelihood = {}
-
-
-def add_node_mpe_likelihood(node_type, lambda_func):
-    _node_mpe_likelihood[node_type] = lambda_func
-
-
 def likelihood(node, data, dtype=np.float64, node_likelihood=_node_likelihood, lls_matrix=None, debug=False):
     all_results = {}
 

--- a/src/spn/structure/leaves/parametric/Inference.py
+++ b/src/spn/structure/leaves/parametric/Inference.py
@@ -18,6 +18,12 @@ def continuous_likelihood(node, data=None, dtype=np.float64):
     probs[~marg_ids] = scipy_obj.pdf(observations, **params)
     return probs
 
+def continuous_log_likelihood(node, data=None, dtype=np.float64):
+    probs, marg_ids, observations = leaf_marginalized_likelihood(node, data, dtype)
+    scipy_obj, params = get_scipy_obj_params(node)
+    probs[~marg_ids] = scipy_obj.logpdf(observations, **params)
+    return probs
+
 
 lognormal_likelihood = continuous_likelihood
 exponential_likelihood = continuous_likelihood
@@ -60,6 +66,11 @@ def categorical_likelihood(node, data=None, dtype=np.float64):
     probs[idx_in] = np.array(node.p)[cat_data[~out_domain_ids]]
     return probs
 
+def categorical_log_likelihood(node, data=None, dtype=np.float64):
+    probs = categorical_likelihood(node, data, dtype)
+    with np.errstate(divide="ignore"):
+        return np.log(probs)
+
 
 def categorical_dictionary_likelihood(node, data=None, dtype=np.float64):
     probs, marg_ids, observations = leaf_marginalized_likelihood(node, data, dtype)
@@ -77,12 +88,12 @@ def uniform_likelihood(node, data=None, dtype=np.float64):
 
 
 def add_parametric_inference_support():
-    add_node_likelihood(Gaussian, continuous_likelihood)
+    add_node_likelihood(Gaussian, continuous_likelihood, continuous_log_likelihood)
     add_node_likelihood(Gamma, gamma_likelihood)
     add_node_likelihood(LogNormal, lognormal_likelihood)
     add_node_likelihood(Poisson, discrete_likelihood)
     add_node_likelihood(Bernoulli, bernoulli_likelihood)
-    add_node_likelihood(Categorical, categorical_likelihood)
+    add_node_likelihood(Categorical, categorical_likelihood, categorical_log_likelihood)
     add_node_likelihood(Geometric, geometric_likelihood)
     add_node_likelihood(Exponential, exponential_likelihood)
     add_node_likelihood(Uniform, uniform_likelihood)

--- a/src/spn/structure/leaves/parametric/MPE.py
+++ b/src/spn/structure/leaves/parametric/MPE.py
@@ -5,12 +5,12 @@ Created on July 02, 2018
 """
 from spn.algorithms.MPE import get_mpe_top_down_leaf, add_node_mpe
 from spn.structure.leaves.parametric.Inference import (
-    continuous_likelihood,
+    continuous_log_likelihood,
     gamma_likelihood,
     lognormal_likelihood,
     discrete_likelihood,
     bernoulli_likelihood,
-    categorical_likelihood,
+    categorical_log_likelihood,
     geometric_likelihood,
     exponential_likelihood,
     categorical_dictionary_likelihood,
@@ -57,7 +57,7 @@ def add_parametric_mpe_support():
 
     add_node_mpe(
         Gaussian,
-        get_parametric_bottom_up_ll(continuous_likelihood, gaussian_mode),
+        get_parametric_bottom_up_ll(continuous_log_likelihood, gaussian_mode),
         get_parametric_top_down_ll(gaussian_mode),
     )
 
@@ -103,7 +103,7 @@ def add_parametric_mpe_support():
 
     add_node_mpe(
         Categorical,
-        get_parametric_bottom_up_ll(categorical_likelihood, categorical_mode),
+        get_parametric_bottom_up_ll(categorical_log_likelihood, categorical_mode),
         get_parametric_top_down_ll(categorical_mode),
     )
 

--- a/src/spn/structure/leaves/piecewise/Inference.py
+++ b/src/spn/structure/leaves/piecewise/Inference.py
@@ -7,7 +7,7 @@ Created on May 4, 2018
 
 import numpy as np
 
-from spn.algorithms.Inference import EPSILON, add_node_likelihood, add_node_mpe_likelihood, leaf_marginalized_likelihood
+from spn.algorithms.Inference import EPSILON, add_node_likelihood, leaf_marginalized_likelihood
 from spn.structure.leaves.piecewise.PiecewiseLinear import PiecewiseLinear
 
 LOG_ZERO = -300


### PR DESCRIPTION
Makes MPE use log likelihoods in the bottom-up pass for categorical and gaussian leaves.
Other leaves are probably still using likelihoods, but I do not use those right now so I could not test any changes here.

See https://github.com/SPFlow/SPFlow/issues/21 for more details.