### PR TITLE
Fix log_node_bottom_up_mpe logspace probs

### DIFF
--- a/src/spn/algorithms/MPE.py
+++ b/src/spn/algorithms/MPE.py
@@ -62,10 +62,15 @@ def log_node_bottom_up_mpe(node, *args, **kwargs):
         return np.log(probs)
 
 
-def add_node_mpe(node_type, bottom_up_lambda, top_down_lambda):
+def add_node_mpe(node_type, bottom_up_lambda, top_down_lambda, log_bottom_up_lambda=None):
     _node_top_down_mpe[node_type] = top_down_lambda
     _node_bottom_up_mpe[node_type] = bottom_up_lambda
-    _node_bottom_up_mpe_log[node_type] = log_node_bottom_up_mpe
+
+    # If no log_bottom_up_lambda method is given, use the generic log_node_buttom_up_mpe method
+    if log_bottom_up_lambda is None:
+        _node_bottom_up_mpe_log[node_type] = log_node_bottom_up_mpe
+    else:
+        _node_bottom_up_mpe_log[node_type] = log_bottom_up_lambda
 
 
 def mpe(

--- a/src/spn/algorithms/MPE.py
+++ b/src/spn/algorithms/MPE.py
@@ -57,7 +57,7 @@ _node_bottom_up_mpe_log = {Sum: sum_log_likelihood, Product: prod_log_likelihood
 
 
 def log_node_bottom_up_mpe(node, *args, **kwargs):
-    probs = _node_bottom_up_mpe[type(node)](node, *args, **kwargs)
+    probs = _node_bottom_up_mpe[type(node)](node, *np.exp(args), **kwargs)
     with np.errstate(divide="ignore"):
         return np.log(probs)
 

--- a/src/spn/algorithms/MPE.py
+++ b/src/spn/algorithms/MPE.py
@@ -57,7 +57,7 @@ _node_bottom_up_mpe_log = {Sum: sum_log_likelihood, Product: prod_log_likelihood
 
 
 def log_node_bottom_up_mpe(node, *args, **kwargs):
-    probs = _node_bottom_up_mpe[type(node)](node, *np.exp(args), **kwargs)
+    probs = _node_bottom_up_mpe[type(node)](node, *args, **kwargs)
     with np.errstate(divide="ignore"):
         return np.log(probs)
 


### PR DESCRIPTION
The function `log_node_bottom_up_mpe` falls back to the non-log bottom_up_mpe method and returns its result in log space. Therefore, the children probs that are passed from below need to be projected back from log into normal space via `np.exp` computing applying bottom_up_mpe.