### PR TITLE
wip: /gpu/tensorflow.py: speeding up speed of converting graph to tensorflow

### DIFF
--- a/src/spn/gpu/TensorFlow.py
+++ b/src/spn/gpu/TensorFlow.py
@@ -22,15 +22,17 @@ logger = logging.getLogger(__name__)
 def log_sum_to_tf_graph(node, children, data_placeholder=None, variable_dict=None, log_space=True, dtype=np.float32):
     assert log_space
     with tf.variable_scope("%s_%s" % (node.__class__.__name__, node.id)):
-        softmaxInverse = np.log(node.weights / np.max(node.weights)).astype(dtype)
-        tfweights = tf.nn.softmax(tf.get_variable("weights", initializer=tf.constant(softmaxInverse)))
+        softmaxInverse = np.log(
+            node.weights / np.max(node.weights)).astype(dtype)
+        tfweights = tf.nn.softmax(tf.get_variable(
+            "weights", initializer=tf.constant(softmaxInverse)))
         variable_dict[node] = tfweights
         childrenprob = tf.stack(children, axis=1)
         return tf.reduce_logsumexp(childrenprob + tf.log(tfweights), axis=1)
 
 
 def tf_graph_to_sum(node, tfvar):
-    node.weights = tfvar.eval().tolist()
+    node.weights = tfvar.tolist()
 
 
 def log_prod_to_tf_graph(node, children, data_placeholder=None, variable_dict=None, log_space=True, dtype=np.float32):
@@ -56,7 +58,8 @@ def histogram_to_tf_graph(node, data_placeholder=None, log_space=True, variable_
         return tf.squeeze(tf.gather(lls, col))
 
 
-_node_log_tf_graph = {Sum: log_sum_to_tf_graph, Product: log_prod_to_tf_graph, Histogram: histogram_to_tf_graph}
+_node_log_tf_graph = {Sum: log_sum_to_tf_graph,
+                      Product: log_prod_to_tf_graph, Histogram: histogram_to_tf_graph}
 
 
 def add_node_to_tf_graph(node_type, lambda_func):
@@ -89,8 +92,14 @@ def spn_to_tf_graph(node, data, batch_size=None, node_tf_graph=_node_log_tf_grap
 
 
 def tf_graph_to_spn(variable_dict, tf_graph_to_node=_tf_graph_to_node):
+    emptylst = []
     for n, tfvars in variable_dict.items():
-        tf_graph_to_node[type(n)](n, tfvars)
+        emptylst.append(tfvars)
+    variable_list = tf.get_default_session().run(emptylst)
+    count = 0
+    for n, tfvars in variable_dict.items():
+        tf_graph_to_node[type(n)](n, variable_list[count])
+        count += 1
 
 
 def likelihood_loss(tf_graph):
@@ -122,7 +131,8 @@ def optimize_tf(
     spn_copy = Copy(spn)
 
     # Compile the SPN to a static tensorflow graph
-    tf_graph, data_placeholder, variable_dict = spn_to_tf_graph(spn_copy, data, batch_size)
+    tf_graph, data_placeholder, variable_dict = spn_to_tf_graph(
+        spn_copy, data, batch_size)
 
     # Optimize the tensorflow graph
     loss_list = optimize_tf_graph(
@@ -160,8 +170,9 @@ def optimize_tf_graph(
 
             # Iterate over batches
             for j in range(batches_per_epoch):
-                data_batch = data[j * batch_size : (j + 1) * batch_size, :]
-                _, batch_loss = sess.run([opt_op, loss], feed_dict={data_placeholder: data_batch})
+                data_batch = data[j * batch_size: (j + 1) * batch_size, :]
+                _, batch_loss = sess.run([opt_op, loss], feed_dict={
+                                         data_placeholder: data_batch})
                 epoch_loss += batch_loss
 
             # Build mean
@@ -203,7 +214,8 @@ def eval_tf_trace(spn, data, log_space=True, save_graph_path=None):
         sess.run(tf.global_variables_initializer())
 
         start = time.perf_counter()
-        result = sess.run(tf_graph, feed_dict={data_placeholder: data}, options=run_options, run_metadata=run_metadata)
+        result = sess.run(tf_graph, feed_dict={
+                          data_placeholder: data}, options=run_options, run_metadata=run_metadata)
         end = time.perf_counter()
 
         e2 = end - start

--- a/src/spn/structure/leaves/parametric/Tensorflow.py
+++ b/src/spn/structure/leaves/parametric/Tensorflow.py
@@ -49,7 +49,8 @@ def exponential_to_tf_graph(node, data_placeholder=None, log_space=True, variabl
 
 def poisson_to_tf_graph(node, data_placeholder=None, log_space=True, variable_dict=None, dtype=np.float32):
     with tf.variable_scope("%s_%s" % (node.__class__.__name__, node.id)):
-        mean = tf.maximum(tf.get_variable("lambda", initializer=node.mean, dtype=dtype), 0.001)
+        mean = tf.maximum(tf.get_variable(
+            "lambda", initializer=node.mean, dtype=dtype), 0.001)
         variable_dict[node] = mean
         dist = tf.distributions.Poisson(rate=mean)
         if log_space:
@@ -60,7 +61,8 @@ def poisson_to_tf_graph(node, data_placeholder=None, log_space=True, variable_di
 
 def bernoulli_to_tf_graph(node, data_placeholder=None, log_space=True, variable_dict=None, dtype=np.float32):
     with tf.variable_scope("%s_%s" % (node.__class__.__name__, node.id)):
-        p = tf.minimum(tf.maximum(tf.get_variable("p", initializer=node.p, dtype=dtype), 0.00000001), 0.9999999)
+        p = tf.minimum(tf.maximum(tf.get_variable(
+            "p", initializer=node.p, dtype=dtype), 0.00000001), 0.9999999)
         variable_dict[node] = p
         dist = tf.distributions.Bernoulli(probs=p)
         if log_space:
@@ -71,8 +73,10 @@ def bernoulli_to_tf_graph(node, data_placeholder=None, log_space=True, variable_
 
 def gamma_to_tf_graph(node, data_placeholder=None, log_space=True, variable_dict=None, dtype=np.float32):
     with tf.variable_scope("%s_%s" % (node.__class__.__name__, node.id)):
-        alpha = tf.maximum(tf.get_variable("alpha", initializer=node.alpha, dtype=dtype), 0.001)
-        beta = tf.maximum(tf.get_variable("beta", initializer=node.beta, dtype=dtype), 0.001)
+        alpha = tf.maximum(tf.get_variable(
+            "alpha", initializer=node.alpha, dtype=dtype), 0.001)
+        beta = tf.maximum(tf.get_variable(
+            "beta", initializer=node.beta, dtype=dtype), 0.001)
         variable_dict[node] = (alpha, beta)
         dist = tf.distributions.Gamma(concentration=alpha, rate=beta)
         if log_space:
@@ -102,7 +106,8 @@ def categorical_to_tf_graph(node, data_placeholder=None, log_space=True, variabl
     with tf.variable_scope("%s_%s" % (node.__class__.__name__, node.id)):
         p = np.array(node.p, dtype=dtype)
         softmaxInverse = np.log(p / np.max(p)).astype(dtype)
-        probs = tf.nn.softmax(tf.get_variable("p", initializer=tf.constant(softmaxInverse)))
+        probs = tf.nn.softmax(tf.get_variable(
+            "p", initializer=tf.constant(softmaxInverse)))
         variable_dict[node] = probs
         if log_space:
             return tf.distributions.Categorical(probs=probs).log_prob(data_placeholder[:, node.scope[0]])
@@ -111,8 +116,8 @@ def categorical_to_tf_graph(node, data_placeholder=None, log_space=True, variabl
 
 
 def tf_graph_to_gaussian(node, tfvar):
-    node.mean = tfvar[0].eval()
-    node.stdev = tfvar[1].eval()
+    node.mean = tfvar[0]
+    node.stdev = tfvar[1]
 
 
 def tf_graph_to_gamma(node, tfvar):


### PR DESCRIPTION
For some reason, Tensorflow was not evaluating the graph lazily which led to absurd slowdowns in the amount of time it took to convert the graph from the spflow structure to the gpu structure.

Thanks to Amur, we sped this up a fair amount and it scales with the size of the graph (whereas the previous method did not). Will attach screenshots + some more documentation