### PR TITLE
Fix typo in Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ from spn.structure.leaves.parametric.Parametric import Categorical
 
 from spn.structure.Base import Sum, Product
 
-from spn.structure.base import assign_ids, rebuild_scopes_bottom_up
+from spn.structure.Base import assign_ids, rebuild_scopes_bottom_up
 
 
 p0 = Product(children=[Categorical(p=[0.3, 0.7], scope=1), Categorical(p=[0.4, 0.6], scope=2)])


### PR DESCRIPTION
This PR changes "base" to "Base" because user can't run this code by the typographic error.