### PR TITLE
Allow RAT-SPNs to take variable-sized batches

### DIFF
--- a/src/spn/experiments/RandomSPNs/RAT_SPN.py
+++ b/src/spn/experiments/RandomSPNs/RAT_SPN.py
@@ -234,7 +234,7 @@ class ProductVector(NodeVector):
             # product == sum in log-domain
             prod = dists1_expand + dists2_expand
             # flatten out the outer product
-            prod = tf.reshape(prod, [dists1.shape[0], num_dist1 * num_dist2])
+            prod = tf.reshape(prod, [tf.shape(dists1)[0], num_dist1 * num_dist2])
 
         return prod
 

--- a/src/spn/experiments/RandomSPNs/train_mnist.py
+++ b/src/spn/experiments/RandomSPNs/train_mnist.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
 
     # dummy_input = np.random.normal(0.0, 1.2, [10, 9])
     dummy_input = train_im[:5]
-    input_ph = tf.placeholder(tf.float32, dummy_input.shape)
+    input_ph = tf.placeholder(tf.float32, [None] + list(dummy_input.shape[1:]))
     output_tensor = spn.forward(input_ph)
     tf_output = sess.run(output_tensor, feed_dict={input_ph: dummy_input})
 


### PR DESCRIPTION
The previous version only worked with fixed sized batches, due to using tensor.shape instead of tf.shape().

Now it also works with variable sized batches, including tf datasets.