### PR TITLE
fix deprecation issue with tf.probability

### DIFF
--- a/src/spn/algorithms/sklearn.py
+++ b/src/spn/algorithms/sklearn.py
@@ -3,6 +3,7 @@ from typing import List
 
 import numpy as np
 import tensorflow as tf
+import tensorflow_probability as tfp
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.utils import check_X_y
 from sklearn.utils.validation import check_array, check_is_fitted
@@ -206,6 +207,6 @@ def classification_categorical_to_tf_graph(
         probs = tf.nn.softmax(tf.constant(softmaxInverse))
         variable_dict[node] = probs
         if log_space:
-            return tf.distributions.Categorical(probs=probs).log_prob(data_placeholder[:, node.scope[0]])
+            return tfp.distributions.Categorical(probs=probs).log_prob(data_placeholder[:, node.scope[0]])
 
-        return tf.distributions.Categorical(probs=probs).prob(data_placeholder[:, node.scope[0]])
+        return tfp.distributions.Categorical(probs=probs).prob(data_placeholder[:, node.scope[0]])

--- a/src/spn/algorithms/sklearn.py
+++ b/src/spn/algorithms/sklearn.py
@@ -3,7 +3,11 @@ from typing import List
 
 import numpy as np
 import tensorflow as tf
-import tensorflow_probability as tfp
+try:
+    import tensorflow_probability as tfp
+    distributions = tfp.distributions
+except:
+    distributions = tf.distributions
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.utils import check_X_y
 from sklearn.utils.validation import check_array, check_is_fitted
@@ -207,6 +211,6 @@ def classification_categorical_to_tf_graph(
         probs = tf.nn.softmax(tf.constant(softmaxInverse))
         variable_dict[node] = probs
         if log_space:
-            return tfp.distributions.Categorical(probs=probs).log_prob(data_placeholder[:, node.scope[0]])
+            return distributions.Categorical(probs=probs).log_prob(data_placeholder[:, node.scope[0]])
 
-        return tfp.distributions.Categorical(probs=probs).prob(data_placeholder[:, node.scope[0]])
+        return distributions.Categorical(probs=probs).prob(data_placeholder[:, node.scope[0]])

--- a/src/spn/structure/leaves/parametric/Tensorflow.py
+++ b/src/spn/structure/leaves/parametric/Tensorflow.py
@@ -67,7 +67,7 @@ def bernoulli_to_tf_graph(node, data_placeholder=None, log_space=True, variable_
     with tf.variable_scope("%s_%s" % (node.__class__.__name__, node.id)):
         p = tf.minimum(tf.maximum(tf.get_variable("p", initializer=node.p, dtype=dtype), 0.00000001), 0.9999999)
         variable_dict[node] = p
-        dist = tfp.distributions.Bernoulli(probs=p)
+        dist = distributions.Bernoulli(probs=p)
         if log_space:
             return dist.log_prob(data_placeholder[:, node.scope[0]])
 

--- a/src/spn/structure/leaves/parametric/Tensorflow.py
+++ b/src/spn/structure/leaves/parametric/Tensorflow.py
@@ -5,8 +5,12 @@ Created on March 21, 2018
 """
 
 import tensorflow as tf
-import tensorflow_probability as tfp
-
+try:
+    import tensorflow_probability as tfp
+    distributions = tfp.distributions
+except:
+    distributions = tf.distributions
+    
 from spn.gpu.TensorFlow import add_node_to_tf_graph, add_tf_graph_to_node
 from spn.structure.leaves.parametric.Parametric import (
     Gaussian,
@@ -29,7 +33,7 @@ def gaussian_to_tf_graph(node, data_placeholder=None, log_space=True, variable_d
         stdev = tf.get_variable("stdev", initializer=node.stdev, dtype=dtype)
         variable_dict[node] = (mean, stdev)
         stdev = tf.maximum(stdev, 0.001)
-        dist = tfp.distributions.Normal(loc=mean, scale=stdev)
+        dist = distributions.Normal(loc=mean, scale=stdev)
         if log_space:
             return dist.log_prob(data_placeholder[:, node.scope[0]])
 
@@ -41,7 +45,7 @@ def exponential_to_tf_graph(node, data_placeholder=None, log_space=True, variabl
         l = tf.get_variable("rate", initializer=node.l, dtype=dtype)
         variable_dict[node] = l
         l = tf.maximum(l, 0.001)
-        dist = tfp.distributions.Exponential(rate=l)
+        dist = distributions.Exponential(rate=l)
         if log_space:
             return dist.log_prob(data_placeholder[:, node.scope[0]])
 
@@ -75,7 +79,7 @@ def gamma_to_tf_graph(node, data_placeholder=None, log_space=True, variable_dict
         alpha = tf.maximum(tf.get_variable("alpha", initializer=node.alpha, dtype=dtype), 0.001)
         beta = tf.maximum(tf.get_variable("beta", initializer=node.beta, dtype=dtype), 0.001)
         variable_dict[node] = (alpha, beta)
-        dist = tfp.distributions.Gamma(concentration=alpha, rate=beta)
+        dist = distributions.Gamma(concentration=alpha, rate=beta)
         if log_space:
             return dist.log_prob(data_placeholder[:, node.scope[0]])
 
@@ -89,7 +93,7 @@ def lognormal_to_tf_graph(node, data_placeholder=None, log_space=True, variable_
         variable_dict[node] = (mean, stdev)
         stdev = tf.maximum(stdev, 0.001)
         dist = tf.contrib.distributions.TransformedDistribution(
-            distribution=tfp.distributions.Normal(loc=mean, scale=stdev),
+            distribution=distributions.Normal(loc=mean, scale=stdev),
             bijector=tf.contrib.distributions.bijectors.Exp(),
             name="LogNormalDistribution",
         )
@@ -106,9 +110,9 @@ def categorical_to_tf_graph(node, data_placeholder=None, log_space=True, variabl
         probs = tf.nn.softmax(tf.get_variable("p", initializer=tf.constant(softmaxInverse)))
         variable_dict[node] = probs
         if log_space:
-            return tfp.distributions.Categorical(probs=probs).log_prob(data_placeholder[:, node.scope[0]])
+            return distributions.Categorical(probs=probs).log_prob(data_placeholder[:, node.scope[0]])
 
-        return tfp.distributions.Categorical(probs=probs).prob(data_placeholder[:, node.scope[0]])
+        return distributions.Categorical(probs=probs).prob(data_placeholder[:, node.scope[0]])
 
 
 def tf_graph_to_gaussian(node, tfvar):

--- a/src/spn/structure/leaves/parametric/Tensorflow.py
+++ b/src/spn/structure/leaves/parametric/Tensorflow.py
@@ -5,6 +5,7 @@ Created on March 21, 2018
 """
 
 import tensorflow as tf
+import tensorflow_probability as tfp
 
 from spn.gpu.TensorFlow import add_node_to_tf_graph, add_tf_graph_to_node
 from spn.structure.leaves.parametric.Parametric import (
@@ -28,7 +29,7 @@ def gaussian_to_tf_graph(node, data_placeholder=None, log_space=True, variable_d
         stdev = tf.get_variable("stdev", initializer=node.stdev, dtype=dtype)
         variable_dict[node] = (mean, stdev)
         stdev = tf.maximum(stdev, 0.001)
-        dist = tf.distributions.Normal(loc=mean, scale=stdev)
+        dist = tfp.distributions.Normal(loc=mean, scale=stdev)
         if log_space:
             return dist.log_prob(data_placeholder[:, node.scope[0]])
 
@@ -40,7 +41,7 @@ def exponential_to_tf_graph(node, data_placeholder=None, log_space=True, variabl
         l = tf.get_variable("rate", initializer=node.l, dtype=dtype)
         variable_dict[node] = l
         l = tf.maximum(l, 0.001)
-        dist = tf.distributions.Exponential(rate=l)
+        dist = tfp.distributions.Exponential(rate=l)
         if log_space:
             return dist.log_prob(data_placeholder[:, node.scope[0]])
 
@@ -62,7 +63,7 @@ def bernoulli_to_tf_graph(node, data_placeholder=None, log_space=True, variable_
     with tf.variable_scope("%s_%s" % (node.__class__.__name__, node.id)):
         p = tf.minimum(tf.maximum(tf.get_variable("p", initializer=node.p, dtype=dtype), 0.00000001), 0.9999999)
         variable_dict[node] = p
-        dist = tf.distributions.Bernoulli(probs=p)
+        dist = tfp.distributions.Bernoulli(probs=p)
         if log_space:
             return dist.log_prob(data_placeholder[:, node.scope[0]])
 
@@ -74,7 +75,7 @@ def gamma_to_tf_graph(node, data_placeholder=None, log_space=True, variable_dict
         alpha = tf.maximum(tf.get_variable("alpha", initializer=node.alpha, dtype=dtype), 0.001)
         beta = tf.maximum(tf.get_variable("beta", initializer=node.beta, dtype=dtype), 0.001)
         variable_dict[node] = (alpha, beta)
-        dist = tf.distributions.Gamma(concentration=alpha, rate=beta)
+        dist = tfp.distributions.Gamma(concentration=alpha, rate=beta)
         if log_space:
             return dist.log_prob(data_placeholder[:, node.scope[0]])
 
@@ -88,7 +89,7 @@ def lognormal_to_tf_graph(node, data_placeholder=None, log_space=True, variable_
         variable_dict[node] = (mean, stdev)
         stdev = tf.maximum(stdev, 0.001)
         dist = tf.contrib.distributions.TransformedDistribution(
-            distribution=tf.distributions.Normal(loc=mean, scale=stdev),
+            distribution=tfp.distributions.Normal(loc=mean, scale=stdev),
             bijector=tf.contrib.distributions.bijectors.Exp(),
             name="LogNormalDistribution",
         )
@@ -105,9 +106,9 @@ def categorical_to_tf_graph(node, data_placeholder=None, log_space=True, variabl
         probs = tf.nn.softmax(tf.get_variable("p", initializer=tf.constant(softmaxInverse)))
         variable_dict[node] = probs
         if log_space:
-            return tf.distributions.Categorical(probs=probs).log_prob(data_placeholder[:, node.scope[0]])
+            return tfp.distributions.Categorical(probs=probs).log_prob(data_placeholder[:, node.scope[0]])
 
-        return tf.distributions.Categorical(probs=probs).prob(data_placeholder[:, node.scope[0]])
+        return tfp.distributions.Categorical(probs=probs).prob(data_placeholder[:, node.scope[0]])
 
 
 def tf_graph_to_gaussian(node, tfvar):


### PR DESCRIPTION
tf.distribution has been moved to tfp.distributions, as this warning shows:

`WARNING:tensorflow:From /usr/local/lib/python3.6/dist-packages/spn/experiments/RandomSPNs/RAT_SPN.py:120: Normal.__init__ (from tensorflow.python.ops.distributions.normal) is deprecated and will be removed after 2019-01-01.

Instructions for updating:
The TensorFlow Distributions library has moved to TensorFlow Probability (https://github.com/tensorflow/probability). You should update all references to use "tfp.distributions" instead of "tf.distributions".`

This PR fixes the issue