### PR TITLE
Add instructions for AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ To install the latest released version of SPFlow using pip
 pip3 install spflow
 ```
 
+An AUR package is available for Arch Linux. The PKGBUILD should automatically apply a patch for SPFlow to work with Tensorflow 2.
+
+```sh
+yay -S python-spflow
+```
+
 ## Examples
 
 We start by creating an SPN. Using a Domain-Specific Language (DSL), we can quickly create an SPN of categorical


### PR DESCRIPTION
This patch adds instructions on how to install SPFlow for Arch Linux
through an AUR package. The PKGBUILD contained within the package should
automatically apply a Tensorflow 2 patch for SPFlow to work with Arch's
rolling release version of Tensorflow.

The contents of the AUR package can be found at
https://aur.archlinux.org/packages/python-spflow.

Signed-off-by: Renato Lui Geh <renatogeh@gmail.com>