### PR TITLE
👷 Documentation built through GitHub Actions

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -1,0 +1,34 @@
+name: Build Deploy Documentation
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Setup Python 🐍
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install and Build 🔧
+        run: |
+          pip install -r requirements.txt
+          cd docs/
+          pip install -r requirements.txt
+          make html
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: docs/build/html/
+          CLEAN: true
+          SINGLE_COMMIT: true


### PR DESCRIPTION
Add `.github/workflows/deploy_pages.yml`

This action builds on the documentation rework in
Pull Request #79. This workflow:

1. Runs when changes are pushed to the `master` branch
2. Clones the repository
3. Sets up Python
4. Installs dependencies and runs `make html`
5. Deploys `docs/build/html/` on a `gh-pages` branch

The GitHub repository settings may be configured to
serve the contents of the `gh-pages` branch, so the
main site will still be built from the
`spflow.github.io` repository, and accessed at:

- `https://spflow.github.io/`

... while the documentation will be served from:

- `https://spflow.github.io/SPFlow/`