### PR TITLE
🐛 Fix Documentation Deploy Bug

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -15,10 +15,11 @@ jobs:
       - name: Setup Python 🐍
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: 3.6
 
       - name: Install and Build 🔧
         run: |
+          sudo apt-get install -y graphviz
           pip install -r requirements.txt
           cd docs/
           pip install -r requirements.txt


### PR DESCRIPTION
- Start building docs against Python 3.6
- Add `sudo apt-get install -y graphviz` to install

This corrects two oversights made in Pull Request #80. Documentation now builds correctly:

- Successful `gh-pages` branch: https://github.com/hayesall/SPFlow/tree/gh-pages
- Build logs: https://github.com/hayesall/SPFlow/runs/750185185