### PR TITLE
🐛 Drop Jekyll configuration and `CLEAN: true`

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -31,5 +31,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
           FOLDER: docs/build/html/
-          CLEAN: true
           SINGLE_COMMIT: true

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-slate


### PR DESCRIPTION
- Drop `_config.yml` that set Jekyll theme
- Drop `CLEAN: true` parameter from `deploy_pages.yml`

The combination of:

```yaml
CLEAN: true
SINGLE_COMMIT: true
```

... seems to handle configuration files in an
unexpected way. Removing the `CLEAN: true` parameter
now results in the `.nojekyll` file being correctly
deployed to the `gh-pages` branch, which then allows
GitHub Pages to properly serve HTML pages without
Jekyll excluding directories with a leading `_`.

---

Here is a live version of the page for demonstration:

- https://iuprohealth.github.io/SPFlow/
- https://github.com/iuprohealth/SPFlow/