### PR TITLE
Revert "layerwise: Do marg. before leaf forward pass"

### DIFF
--- a/src/spn/algorithms/layerwise/distributions.py
+++ b/src/spn/algorithms/layerwise/distributions.py
@@ -152,8 +152,9 @@ class Leaf(AbstractLayer):
     def forward(self, x):
         # Forward through base distribution
         d = self._get_base_distribution()
-        x = self._marginalize_input(x)
         x = dist_forward(d, x)
+
+        x = self._marginalize_input(x)
         x = self._apply_dropout(x)
 
         return x


### PR DESCRIPTION
This reverts commit 8de0ad4addd5fd62c532ab4956c1b75b1cb433e8.

Marginalizing before computing the LL w.r.t. the given distribution leads to interpreting the probabilities of "1.0" (from marginalization) as real values at the leaf layer. Therefore, do the marginalization *after* computing the LLs from the leaf layer.