### PR TITLE
Remove package versions from requirements.txt (fix #72).

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-scipy==1.2
+scipy
 sklearn
 statsmodels
 networkx
@@ -8,9 +8,9 @@ matplotlib
 pydot
 lark-parser
 tqdm
-ete3>=3.1.1
+ete3
 sympy
-PyQt5==5.9.2
+PyQt5
 arff
 pytest
 dataclasses


### PR DESCRIPTION
I am not aware of the consequences, but this allowed me to install SPFlow requirements in Python >= 3.8 (as seen in https://github.com/SPFlow/SPFlow/issues/72).