### PR TITLE
Drop `clip_on` keyword argument from spn.io.Graphics

### DIFF
--- a/src/spn/io/Graphics.py
+++ b/src/spn/io/Graphics.py
@@ -73,7 +73,7 @@ def draw_spn(spn):
     )
     ax.collections[0].set_edgecolor("#333333")
     edge_labels = nx.draw_networkx_edge_labels(
-        g, pos=pos, edge_labels=nx.get_edge_attributes(g, "weight"), font_size=16, clip_on=False, alpha=0.6
+        g, pos=pos, edge_labels=nx.get_edge_attributes(g, "weight"), font_size=16, alpha=0.6
     )
 
     xpos = list(map(lambda p: p[0], pos.values()))


### PR DESCRIPTION
Resolves #89

Fix keyword argument `clip_on` that behaved differently for 2.4/2.5

In `networkx==2.4`, `clip_on` could be passed as a keyword argument,
but it was unused. In `networkx==2.5` arbitrary keyword arguments
appear to no longer be passed. In the prerelease for
`networkx==2.6`, `clip_on` appears to be added back in as an explicit
parameter.

This drops the keyword argument to avoid these problems.