### PR TITLE
Refactor code to eliminate inefficient FOR-loops and use .join() isntead

### DIFF
--- a/src/spn/algorithms/measures/InformationTheory.py
+++ b/src/spn/algorithms/measures/InformationTheory.py
@@ -138,12 +138,10 @@ def print_debug_info(ds_context, X, Y, cond_Z):
                shows the entropy which is on calculation.
     !!!
     """
-    v4print = " "
     c_Z = np.array(list(cond_Z))
     x = np.array(list(X))
     y = np.array(list(Y))
-    for index in c_Z:
-        v4print = v4print + str(ds_context.domains[index].size) + " * "
+    v4print = " " + " * ".join([str(ds_context.domains[index].size) for index in c_Z])
     logger.info(
         "Number of permutation in CMI: n1(",
         ds_context.domains[x[0]].size,


### PR DESCRIPTION
Thank you very much for your excellent work in SPFlow.
I am a graduate student at the University of Colorado-Boulder, studying the best practices of evolving ML codes. According to our research, one of the best practices is migration of loop-based computations since it typically results in better speed and code quality. Therefore, we made the following changes in SPFlow, which remove the FOR loop and use join(). I carefully checked the modification to ensure that it does not break the code. I will gladly contribute. Please help me to merge this.