### PR TITLE
Fix classmethod naming convention (self -> cls)

### DIFF
--- a/.github/workflows/github-actions-build-python.yml
+++ b/.github/workflows/github-actions-build-python.yml
@@ -1,6 +1,10 @@
 name: Development Build & Test
 
-on: [push]
+on:
+  release:
+    types: [ published ]
+  pull_request:
+  push:
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -575,11 +575,11 @@ class MyModule(Module):
     ...
 
     @classmethod
-    accepts(self, signature: List[FeatureContext]) -> bool:
+    accepts(cls, signature: List[FeatureContext]) -> bool:
         ...
     
     @classmethod
-    from_signatures(self, signatures: List[FeatureContext]) -> "MyModyle":
+    from_signatures(cls, signatures: List[FeatureContext]) -> "MyModyle":
         ...
 
 ```

--- a/src/spflow/base/structure/autoleaf.py
+++ b/src/spflow/base/structure/autoleaf.py
@@ -167,7 +167,7 @@ class AutoLeaf:
         return leaf_type.from_signatures(signatures)
 
     @classmethod
-    def __push_down(self, key) -> None:
+    def __push_down(cls, key) -> None:
         """TODO"""
         if key not in self.__leaf_map.keys():
             return
@@ -178,7 +178,7 @@ class AutoLeaf:
         self.__leaf_map[key + 1] = value
 
     @classmethod
-    def __next_key(self, start: Optional[int] = None) -> id:
+    def __next_key(cls, start: Optional[int] = None) -> id:
         """TODO"""
         if start is None:
             # start from beginning
@@ -257,12 +257,12 @@ class AutoLeaf:
             self.__leaf_map[before] = module
 
     @classmethod
-    def is_registered(self, module) -> bool:
+    def is_registered(cls, module) -> bool:
         """TODO"""
         return module in list(self.__leaf_map.values())
 
     @classmethod
-    def infer(self, signatures: List[FeatureContext]) -> Union[Module, None]:  # type: ignore
+    def infer(cls, signatures: List[FeatureContext]) -> Union[Module, None]:  # type: ignore
         """TODO"""
         keys = sorted(list(self.__leaf_map.keys()))
 

--- a/src/spflow/base/structure/autoleaf.py
+++ b/src/spflow/base/structure/autoleaf.py
@@ -169,13 +169,13 @@ class AutoLeaf:
     @classmethod
     def __push_down(cls, key) -> None:
         """TODO"""
-        if key not in self.__leaf_map.keys():
+        if key not in cls.__leaf_map.keys():
             return
-        if key + 1 in self.__leaf_map.keys():
-            self.__push_down(key + 1)
+        if key + 1 in cls.__leaf_map.keys():
+            cls.__push_down(key + 1)
         # delete entry under current id
-        value = self.__leaf_map.pop(key)
-        self.__leaf_map[key + 1] = value
+        value = cls.__leaf_map.pop(key)
+        cls.__leaf_map[key + 1] = value
 
     @classmethod
     def __next_key(cls, start: Optional[int] = None) -> id:
@@ -187,7 +187,7 @@ class AutoLeaf:
             key = start
 
         # find next best available value
-        while key in self.__leaf_map.keys():
+        while key in cls.__leaf_map.keys():
             key += 1
 
         return key
@@ -259,15 +259,15 @@ class AutoLeaf:
     @classmethod
     def is_registered(cls, module) -> bool:
         """TODO"""
-        return module in list(self.__leaf_map.values())
+        return module in list(cls.__leaf_map.values())
 
     @classmethod
     def infer(cls, signatures: List[FeatureContext]) -> Union[Module, None]:  # type: ignore
         """TODO"""
-        keys = sorted(list(self.__leaf_map.keys()))
+        keys = sorted(list(cls.__leaf_map.keys()))
 
         for key in keys:
-            if self.__leaf_map[key].accepts(signatures):
-                return self.__leaf_map[key]
+            if cls.__leaf_map[key].accepts(signatures):
+                return cls.__leaf_map[key]
 
         return None

--- a/src/spflow/base/structure/general/layers/leaves/parametric/bernoulli.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/bernoulli.py
@@ -122,7 +122,7 @@ class BernoulliLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "BernoulliLayer":
         """Creates an instance from a specified signature.
 
@@ -132,7 +132,7 @@ class BernoulliLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'BernoulliLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/layers/leaves/parametric/bernoulli.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/bernoulli.py
@@ -102,7 +102,7 @@ class BernoulliLayer(Module):
         return np.array([node.p for node in self.nodes])
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``BernoulliLayer`` can represent one or more univariate nodes with ``MetaType.discrete`` or ``BernoulliType`` domains.

--- a/src/spflow/base/structure/general/layers/leaves/parametric/binomial.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/binomial.py
@@ -134,7 +134,7 @@ class BinomialLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "BinomialLayer":
         """Creates an instance from a specified signature.
 
@@ -144,7 +144,7 @@ class BinomialLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'BinomialLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/layers/leaves/parametric/binomial.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/binomial.py
@@ -114,7 +114,7 @@ class BinomialLayer(Module):
         return np.array([node.p for node in self.nodes])
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``BinomialLayer`` can represent one or more univariate nodes with ``BinomialType`` domains.

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_bernoulli.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_bernoulli.py
@@ -106,7 +106,7 @@ class CondBernoulliLayer(Module):
         return self._n_out
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondBernoulliLayer`` can represent one or more univariate nodes with ``MetaType.Discrete`` or ``BernoulliType`` domains.

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_bernoulli.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_bernoulli.py
@@ -126,7 +126,7 @@ class CondBernoulliLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondBernoulliLayer":
         """Creates an instance from a specified signature.
 
@@ -136,7 +136,7 @@ class CondBernoulliLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondBernoulliLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_binomial.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_binomial.py
@@ -122,7 +122,7 @@ class CondBinomialLayer(Module):
         return np.array([node.n for node in self.nodes])
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondBinomialLayer`` can represent one or more univariate nodes with ``BinomialType`` domains.

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_binomial.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_binomial.py
@@ -142,7 +142,7 @@ class CondBinomialLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondBinomialLayer":
         """Creates an instance from a specified signature.
 
@@ -152,7 +152,7 @@ class CondBinomialLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondBinomialLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_exponential.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_exponential.py
@@ -106,7 +106,7 @@ class CondExponentialLayer(Module):
         return self._n_out
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondExponentialLayer`` can represent one or more univariate nodes with ``MetaType.Continuous`` or ``ExponentialType`` domains.

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_exponential.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_exponential.py
@@ -126,7 +126,7 @@ class CondExponentialLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondExponentialLayer":
         """Creates an instance from a specified signature.
 
@@ -136,7 +136,7 @@ class CondExponentialLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondExponentialLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_gamma.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_gamma.py
@@ -106,7 +106,7 @@ class CondGammaLayer(Module):
         return self._n_out
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondGammaLayer`` can represent one or more univariate nodes with ``MetaType.Continuous`` or ``GammaType`` domains.

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_gamma.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_gamma.py
@@ -126,7 +126,7 @@ class CondGammaLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondGammaLayer":
         """Creates an instance from a specified signature.
 
@@ -136,7 +136,7 @@ class CondGammaLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondGammaLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_gaussian.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_gaussian.py
@@ -124,7 +124,7 @@ class CondGaussianLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondGaussianLayer":
         """Creates an instance from a specified signature.
 
@@ -134,7 +134,7 @@ class CondGaussianLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondGaussianLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_gaussian.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_gaussian.py
@@ -104,7 +104,7 @@ class CondGaussianLayer(Module):
         return self._n_out
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondGaussianLayer`` can represent one or more univariate nodes with ``MetaType.Continuous`` or ``GaussianType`` domains.

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_geometric.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_geometric.py
@@ -123,7 +123,7 @@ class CondGeometricLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondGeometricLayer":
         """Creates an instance from a specified signature.
 
@@ -133,7 +133,7 @@ class CondGeometricLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondGeometricLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_geometric.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_geometric.py
@@ -103,7 +103,7 @@ class CondGeometricLayer(Module):
         return self._n_out
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondGeometricLayer`` can represent one or more univariate nodes with ``MetaType.Discrete`` or ``GeometricType`` domains.

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_log_normal.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_log_normal.py
@@ -104,7 +104,7 @@ class CondLogNormalLayer(Module):
         return self._n_out
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondLogNormalLayer`` can represent one or more univariate nodes with ``MetaType.Continuous`` or ``LogNormalType`` domains.

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_log_normal.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_log_normal.py
@@ -124,7 +124,7 @@ class CondLogNormalLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondLogNormalLayer":
         """Creates an instance from a specified signature.
 
@@ -134,7 +134,7 @@ class CondLogNormalLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondLogNormalLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_multivariate_gaussian.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_multivariate_gaussian.py
@@ -140,7 +140,7 @@ class CondMultivariateGaussianLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondMultivariateGaussianLayer":
         """Creates an instance from a specified signature.
 
@@ -150,7 +150,7 @@ class CondMultivariateGaussianLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondMultivariateGaussianLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_multivariate_gaussian.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_multivariate_gaussian.py
@@ -120,7 +120,7 @@ class CondMultivariateGaussianLayer(Module):
         return self._n_out
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondMultivariateGaussianLayer`` can represent one or more multivariate nodes with ``MetaType.Continuous`` or ``GammaType`` domains.

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_negative_binomial.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_negative_binomial.py
@@ -138,7 +138,7 @@ class CondNegativeBinomialLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondNegativeBinomialLayer":
         """Creates an instance from a specified signature.
 
@@ -148,7 +148,7 @@ class CondNegativeBinomialLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondNegativeBinomialLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_negative_binomial.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_negative_binomial.py
@@ -118,7 +118,7 @@ class CondNegativeBinomialLayer(Module):
         return np.array([node.n for node in self.nodes])
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondNegativeBinomial`` can represent one or more univariate nodes with ``NegativeBinomialType`` domains.

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_poisson.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_poisson.py
@@ -103,7 +103,7 @@ class CondPoissonLayer(Module):
         return self._n_out
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondPoissonLayer`` can represent one or more univariate nodes with ``MetaType.Discrete`` or ``PoissonType`` domains.

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_poisson.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_poisson.py
@@ -123,7 +123,7 @@ class CondPoissonLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondPoissonLayer":
         """Creates an instance from a specified signature.
 
@@ -133,7 +133,7 @@ class CondPoissonLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondPoissonLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/layers/leaves/parametric/exponential.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/exponential.py
@@ -102,7 +102,7 @@ class ExponentialLayer(Module):
         return np.array([node.l for node in self.nodes])
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``ExponentialLayer`` can represent one or more univariate nodes with ``MetaType.Continuous`` or ``ExponentialType`` domains.

--- a/src/spflow/base/structure/general/layers/leaves/parametric/exponential.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/exponential.py
@@ -122,7 +122,7 @@ class ExponentialLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "ExponentialLayer":
         """Creates an instance from a specified signature.
 
@@ -132,7 +132,7 @@ class ExponentialLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'ExponentialLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/layers/leaves/parametric/gamma.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/gamma.py
@@ -112,7 +112,7 @@ class GammaLayer(Module):
         return np.array([node.beta for node in self.nodes])
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``GammaLayer`` can represent one or more univariate nodes with ``MetaType.Continuous`` or ``GammaType`` domains.
@@ -131,7 +131,7 @@ class GammaLayer(Module):
         return True
 
     @classmethod
-    def from_signatures(self, signatures: List[FeatureContext]) -> "GammaLayer":
+    def from_signatures(cls, signatures: List[FeatureContext]) -> "GammaLayer":
         """Creates an instance from a specified signature.
 
         Returns:

--- a/src/spflow/base/structure/general/layers/leaves/parametric/gamma.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/gamma.py
@@ -140,7 +140,7 @@ class GammaLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'GammaLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/layers/leaves/parametric/gaussian.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/gaussian.py
@@ -134,7 +134,7 @@ class GaussianLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "GaussianLayer":
         """Creates an instance from a specified signature.
 
@@ -144,7 +144,7 @@ class GaussianLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'GaussianLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/layers/leaves/parametric/gaussian.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/gaussian.py
@@ -114,7 +114,7 @@ class GaussianLayer(Module):
         return np.array([node.std for node in self.nodes])
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``GaussianLayer`` can represent one or more univariate nodes with ``MetaType.Continuous`` or ``GaussianType`` domains.

--- a/src/spflow/base/structure/general/layers/leaves/parametric/geometric.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/geometric.py
@@ -121,7 +121,7 @@ class GeometricLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "GeometricLayer":
         """Creates an instance from a specified signature.
 
@@ -131,7 +131,7 @@ class GeometricLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'GeometricLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/layers/leaves/parametric/geometric.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/geometric.py
@@ -101,7 +101,7 @@ class GeometricLayer(Module):
         return np.array([node.p for node in self.nodes])
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``GeometricLayer`` can represent one or more univariate nodes with ``MetaType.Discrete`` or ``GeometricType`` domains.

--- a/src/spflow/base/structure/general/layers/leaves/parametric/hypergeometric.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/hypergeometric.py
@@ -125,7 +125,7 @@ class HypergeometricLayer(Module):
         return np.array([node.n for node in self.nodes])
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``HypergeometricLayer`` can represent one or more univariate nodes with ``HypergeometricType`` domains.

--- a/src/spflow/base/structure/general/layers/leaves/parametric/hypergeometric.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/hypergeometric.py
@@ -145,7 +145,7 @@ class HypergeometricLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "HypergeometricLayer":
         """Creates an instance from a specified signature.
 
@@ -155,7 +155,7 @@ class HypergeometricLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'HypergeometricLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/layers/leaves/parametric/log_normal.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/log_normal.py
@@ -134,7 +134,7 @@ class LogNormalLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "LogNormalLayer":
         """Creates an instance from a specified signature.
 
@@ -144,7 +144,7 @@ class LogNormalLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'LogNormalLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/layers/leaves/parametric/log_normal.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/log_normal.py
@@ -114,7 +114,7 @@ class LogNormalLayer(Module):
         return np.array([node.std for node in self.nodes])
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``LogNormalLayer`` can represent one or more univariate nodes with ``MetaType.Continuous`` or ``LogNormalType`` domains.

--- a/src/spflow/base/structure/general/layers/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/multivariate_gaussian.py
@@ -131,7 +131,7 @@ class MultivariateGaussianLayer(Module):
         return [node.cov for node in self.nodes]
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``MultivariateGaussianLayer`` can represent one or more multivariate nodes with ``MetaType.Continuous`` or ``GaussianType`` domains.

--- a/src/spflow/base/structure/general/layers/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/multivariate_gaussian.py
@@ -151,7 +151,7 @@ class MultivariateGaussianLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "MultivariateGaussianLayer":
         """Creates an instance from a specified signature.
 
@@ -161,7 +161,7 @@ class MultivariateGaussianLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'MultivariateGaussianLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/layers/leaves/parametric/negative_binomial.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/negative_binomial.py
@@ -133,7 +133,7 @@ class NegativeBinomialLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "NegativeBinomialLayer":
         """Creates an instance from a specified signature.
 
@@ -143,7 +143,7 @@ class NegativeBinomialLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'NegativeBinomialLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/layers/leaves/parametric/negative_binomial.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/negative_binomial.py
@@ -113,7 +113,7 @@ class NegativeBinomialLayer(Module):
         return np.array([node.p for node in self.nodes])
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``NegativeBinomialLayer`` can represent one or more univariate nodes ``NegativeBinomialType`` domains.

--- a/src/spflow/base/structure/general/layers/leaves/parametric/poisson.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/poisson.py
@@ -119,7 +119,7 @@ class PoissonLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "PoissonLayer":
         """Creates an instance from a specified signature.
 
@@ -129,7 +129,7 @@ class PoissonLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'PoissonLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/layers/leaves/parametric/poisson.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/poisson.py
@@ -99,7 +99,7 @@ class PoissonLayer(Module):
         return np.array([node.l for node in self.nodes])
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``PoissonLayer`` can represent one or more univariate nodes with ``MetaType.Discrete`` or ``PoissonType`` domains.

--- a/src/spflow/base/structure/general/layers/leaves/parametric/uniform.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/uniform.py
@@ -128,7 +128,7 @@ class UniformLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "UniformLayer":
         """Creates an instance from a specified signature.
 
@@ -138,7 +138,7 @@ class UniformLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'UniformLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/layers/leaves/parametric/uniform.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/uniform.py
@@ -108,7 +108,7 @@ class UniformLayer(Module):
         return np.array([node.end for node in self.nodes])
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``UniformLayer`` can represent one or more univariate nodes with ``UniformType`` domains.

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/bernoulli.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/bernoulli.py
@@ -103,7 +103,7 @@ class Bernoulli(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'Bernoulli' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/bernoulli.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/bernoulli.py
@@ -59,7 +59,7 @@ class Bernoulli(LeafNode):
         self.set_params(p)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``Bernoulli`` can represent a single univariate node with ``MetaType.Discrete`` or ``BernoulliType`` domain.
@@ -94,7 +94,7 @@ class Bernoulli(LeafNode):
         return True
 
     @classmethod
-    def from_signatures(self, signatures: List[FeatureContext]) -> "Bernoulli":
+    def from_signatures(cls, signatures: List[FeatureContext]) -> "Bernoulli":
         """Creates an instance from a specified signature.
 
         Returns:

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/binomial.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/binomial.py
@@ -102,7 +102,7 @@ class Binomial(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'Binomial' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/binomial.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/binomial.py
@@ -61,7 +61,7 @@ class Binomial(LeafNode):
         self.set_params(n, p)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``Binomial`` can represent a single univariate node with ``BinomialType`` domain.
@@ -93,7 +93,7 @@ class Binomial(LeafNode):
         return True
 
     @classmethod
-    def from_signatures(self, signatures: List[FeatureContext]) -> "Binomial":
+    def from_signatures(cls, signatures: List[FeatureContext]) -> "Binomial":
         """Creates an instance from a specified signature.
 
         Returns:

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_bernoulli.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_bernoulli.py
@@ -96,7 +96,7 @@ class CondBernoulli(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondBernoulli":
         """Creates an instance from a specified signature.
 
@@ -106,7 +106,7 @@ class CondBernoulli(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondBernoulli' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_bernoulli.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_bernoulli.py
@@ -60,7 +60,7 @@ class CondBernoulli(LeafNode):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondBernoulli`` can represent a single univariate node with ``MetaType.Discrete`` or ``BernoulliType`` domain.

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_binomial.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_binomial.py
@@ -70,7 +70,7 @@ class CondBinomial(LeafNode):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondBinomial`` can represent a single univariate node with ``BinomialType`` domain.

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_binomial.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_binomial.py
@@ -103,7 +103,7 @@ class CondBinomial(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondBinomial":
         """Creates an instance from a specified signature.
 
@@ -113,7 +113,7 @@ class CondBinomial(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondBinomial' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_exponential.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_exponential.py
@@ -96,7 +96,7 @@ class CondExponential(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondExponential":
         """Creates an instance from a specified signature.
 
@@ -106,7 +106,7 @@ class CondExponential(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondExponential' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_exponential.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_exponential.py
@@ -60,7 +60,7 @@ class CondExponential(LeafNode):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondExponential`` can represent a single univariate node with ``MetaType.Continuous`` or ``ExponentialType`` domain.

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_gamma.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_gamma.py
@@ -106,7 +106,7 @@ class CondGamma(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondGamma' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_gamma.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_gamma.py
@@ -62,7 +62,7 @@ class CondGamma(LeafNode):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondGamma`` can represent a single univariate node with ``MetaType.Continuous`` or ``GammaType`` domain.
@@ -97,7 +97,7 @@ class CondGamma(LeafNode):
         return True
 
     @classmethod
-    def from_signatures(self, signatures: List[FeatureContext]) -> "CondGamma":
+    def from_signatures(cls, signatures: List[FeatureContext]) -> "CondGamma":
         """Creates an instance from a specified signature.
 
         Returns:

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_gaussian.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_gaussian.py
@@ -100,7 +100,7 @@ class CondGaussian(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondGaussian":
         """Creates an instance from a specified signature.
 
@@ -110,7 +110,7 @@ class CondGaussian(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondGaussian' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_gaussian.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_gaussian.py
@@ -64,7 +64,7 @@ class CondGaussian(LeafNode):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondGaussian`` can represent a single univariate node with ``MetaType.Continuous`` or ``GamamType`` domain.

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_geometric.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_geometric.py
@@ -59,7 +59,7 @@ class CondGeometric(LeafNode):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondGeometric`` can represent a single univariate node with ``MetaType.Discrete`` or ``GeometricType`` domain.

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_geometric.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_geometric.py
@@ -95,7 +95,7 @@ class CondGeometric(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondGeometric":
         """Creates an instance from a specified signature.
 
@@ -105,7 +105,7 @@ class CondGeometric(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondGeometric' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_log_normal.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_log_normal.py
@@ -96,7 +96,7 @@ class CondLogNormal(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondLogNormal":
         """Creates an instance from a specified signature.
 
@@ -106,7 +106,7 @@ class CondLogNormal(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondLogNormal' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_log_normal.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_log_normal.py
@@ -60,7 +60,7 @@ class CondLogNormal(LeafNode):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondLogNormal`` can represent a single univariate node with ``MetaType.Continuous`` or ``LogNormalType`` domain.

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_multivariate_gaussian.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_multivariate_gaussian.py
@@ -122,7 +122,7 @@ class CondMultivariateGaussian(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondMultivariateGaussian":
         """Creates an instance from a specified signature.
 
@@ -132,7 +132,7 @@ class CondMultivariateGaussian(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondMultivariateGaussian' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_multivariate_gaussian.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_multivariate_gaussian.py
@@ -83,7 +83,7 @@ class CondMultivariateGaussian(LeafNode):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondMultivariateGaussian`` can represent a single multivariate node with ``MetaType.Continuous`` or ``GaussianType`` domains.

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_negative_binomial.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_negative_binomial.py
@@ -102,7 +102,7 @@ class CondNegativeBinomial(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondNegativeBinomial":
         """Creates an instance from a specified signature.
 
@@ -112,7 +112,7 @@ class CondNegativeBinomial(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondNegativeBinomial' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_negative_binomial.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_negative_binomial.py
@@ -69,7 +69,7 @@ class CondNegativeBinomial(LeafNode):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondNegativeBinomial`` can represent a single univariate node with ``NegativeBinomialType`` domain.

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_poisson.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_poisson.py
@@ -59,7 +59,7 @@ class CondPoisson(LeafNode):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondPoisson`` can represent a single univariate node with ``MetaType.Discrete`` or ``PoissonType`` domain.

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_poisson.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_poisson.py
@@ -95,7 +95,7 @@ class CondPoisson(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondPoisson":
         """Creates an instance from a specified signature.
 
@@ -105,7 +105,7 @@ class CondPoisson(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondPoisson' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/exponential.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/exponential.py
@@ -54,7 +54,7 @@ class Exponential(LeafNode):
         self.set_params(l)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``Exponential`` can represent a single univariate node with ``MetaType.Continuous`` or ``ExponentialType`` domain.

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/exponential.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/exponential.py
@@ -90,7 +90,7 @@ class Exponential(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "Exponential":
         """Creates an instance from a specified signature.
 
@@ -100,7 +100,7 @@ class Exponential(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'Exponential' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/gamma.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/gamma.py
@@ -110,7 +110,7 @@ class Gamma(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'Gamma' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/gamma.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/gamma.py
@@ -66,7 +66,7 @@ class Gamma(LeafNode):
         self.set_params(alpha, beta)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``Gamma`` can represent a single univariate node with ``MetaType.Continuous`` or ``GammaType`` domain.
@@ -101,7 +101,7 @@ class Gamma(LeafNode):
         return True
 
     @classmethod
-    def from_signatures(self, signatures: List[FeatureContext]) -> "Gamma":
+    def from_signatures(cls, signatures: List[FeatureContext]) -> "Gamma":
         """Creates an instance from a specified signature.
 
         Returns:

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/gaussian.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/gaussian.py
@@ -64,7 +64,7 @@ class Gaussian(LeafNode):
         self.set_params(mean, std)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``Gaussian`` can represent a single univariate node with ``MetaType.Continuous`` or ``GaussianType`` domain.
@@ -99,7 +99,7 @@ class Gaussian(LeafNode):
         return True
 
     @classmethod
-    def from_signatures(self, signatures: List[FeatureContext]) -> "Gaussian":
+    def from_signatures(cls, signatures: List[FeatureContext]) -> "Gaussian":
         """Creates an instance from a specified signature.
 
         Returns:

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/gaussian.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/gaussian.py
@@ -108,7 +108,7 @@ class Gaussian(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'Gaussian' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/geometric.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/geometric.py
@@ -97,7 +97,7 @@ class Geometric(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'Geometric' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/geometric.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/geometric.py
@@ -53,7 +53,7 @@ class Geometric(LeafNode):
         self.set_params(p)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``Geometric`` can represent a single univariate node with ``MetaType.Discrete`` or ``GeometricType`` domain.
@@ -88,7 +88,7 @@ class Geometric(LeafNode):
         return True
 
     @classmethod
-    def from_signatures(self, signatures: List[FeatureContext]) -> "Geometric":
+    def from_signatures(cls, signatures: List[FeatureContext]) -> "Geometric":
         """Creates an instance from a specified signature.
 
         Returns:

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/hypergeometric.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/hypergeometric.py
@@ -63,7 +63,7 @@ class Hypergeometric(LeafNode):
         self.set_params(N, M, n)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``Hypergeometric`` can represent a single univariate node with ``HypergeometricType`` domain.

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/hypergeometric.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/hypergeometric.py
@@ -96,7 +96,7 @@ class Hypergeometric(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "Hypergeometric":
         """Creates an instance from a specified signature.
 
@@ -106,7 +106,7 @@ class Hypergeometric(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'Hypergeometric' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/log_normal.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/log_normal.py
@@ -63,7 +63,7 @@ class LogNormal(LeafNode):
         self.set_params(mean, std)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``LogNormal`` can represent a single univariate node with ``MetaType.Continuous`` or ``LogNormalType`` domain.
@@ -98,7 +98,7 @@ class LogNormal(LeafNode):
         return True
 
     @classmethod
-    def from_signatures(self, signatures: List[FeatureContext]) -> "LogNormal":
+    def from_signatures(cls, signatures: List[FeatureContext]) -> "LogNormal":
         """Creates an instance from a specified signature.
 
         Returns:

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/log_normal.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/log_normal.py
@@ -107,7 +107,7 @@ class LogNormal(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'LogNormal' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/multivariate_gaussian.py
@@ -125,7 +125,7 @@ class MultivariateGaussian(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "MultivariateGaussian":
         """Creates an instance from a specified signature.
 
@@ -135,7 +135,7 @@ class MultivariateGaussian(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'MultivariateGaussian' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/multivariate_gaussian.py
@@ -86,7 +86,7 @@ class MultivariateGaussian(LeafNode):
         self.set_params(mean, cov)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``MultivariateGaussian`` can represent a single univariate node with ``MetaType.Continuous`` or ``GaussianType`` domains.

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/negative_binomial.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/negative_binomial.py
@@ -91,7 +91,7 @@ class NegativeBinomial(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "NegativeBinomial":
         """Creates an instance from a specified signature.
 
@@ -101,7 +101,7 @@ class NegativeBinomial(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'NegativeBinomial' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/negative_binomial.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/negative_binomial.py
@@ -58,7 +58,7 @@ class NegativeBinomial(LeafNode):
         self.set_params(n, p)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``NegativeBinomial`` can represent a single univariate node with ``NegativeBinomialType`` domain.

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/poisson.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/poisson.py
@@ -53,7 +53,7 @@ class Poisson(LeafNode):
         self.set_params(l)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``Poisson`` can represent a single univariate node with ``MetaType.Discrete`` or ``PoissonType`` domain.
@@ -88,7 +88,7 @@ class Poisson(LeafNode):
         return True
 
     @classmethod
-    def from_signatures(self, signatures: List[FeatureContext]) -> "Poisson":
+    def from_signatures(cls, signatures: List[FeatureContext]) -> "Poisson":
         """Creates an instance from a specified signature.
 
         Returns:

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/poisson.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/poisson.py
@@ -97,7 +97,7 @@ class Poisson(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'Poisson' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/uniform.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/uniform.py
@@ -67,7 +67,7 @@ class Uniform(LeafNode):
         self.set_params(start, end, support_outside)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``Uniform`` can represent a single univariate node with with ``UniformType`` domain.
@@ -99,7 +99,7 @@ class Uniform(LeafNode):
         return True
 
     @classmethod
-    def from_signatures(self, signatures: List[FeatureContext]) -> "Uniform":
+    def from_signatures(cls, signatures: List[FeatureContext]) -> "Uniform":
         """Creates an instance from a specified signature.
 
         Returns:

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/uniform.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/uniform.py
@@ -108,7 +108,7 @@ class Uniform(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'Uniform' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/meta/data/feature_context.py
+++ b/src/spflow/meta/data/feature_context.py
@@ -38,7 +38,7 @@ class FeatureContext:
         self.set_domains(domains)
 
     @classmethod
-    def parse_type(self, type: FeatureType):
+    def parse_type(cls, type: FeatureType):
         """TODO"""
         if isclass(type):
             type = type()

--- a/src/spflow/meta/data/feature_types.py
+++ b/src/spflow/meta/data/feature_types.py
@@ -273,7 +273,7 @@ class FeatureTypes(ABC):
     Poisson = PoissonType
 
     @classmethod
-    def register(self, name: str, type: FeatureType, overwrite=False) -> None:
+    def register(cls, name: str, type: FeatureType, overwrite=False) -> None:
         """Registers a feature type.
 
         Args:

--- a/src/spflow/meta/data/feature_types.py
+++ b/src/spflow/meta/data/feature_types.py
@@ -285,9 +285,9 @@ class FeatureTypes(ABC):
                 Boolean indicating whether or not to overwrite any potentially existing feature type registered under the same name.
                 Defaults to False.
         """
-        if hasattr(self, name) and not overwrite:
+        if hasattr(cls, name) and not overwrite:
             raise ValueError(
                 "Feature type {name} is already registered. If type should be overwritten, enable 'overwrite'."
             )
 
-        setattr(self, name, type)
+        setattr(cls, name, type)

--- a/src/spflow/meta/data/meta_type.py
+++ b/src/spflow/meta/data/meta_type.py
@@ -13,5 +13,5 @@ class MetaType(Enum):
     Discrete: int = 1
 
     @classmethod
-    def get_params(self) -> Tuple:
+    def get_params(cls) -> Tuple:
         return tuple([])

--- a/src/spflow/torch/structure/autoleaf.py
+++ b/src/spflow/torch/structure/autoleaf.py
@@ -169,13 +169,13 @@ class AutoLeaf:
     @classmethod
     def __push_down(cls, key) -> None:
         """TODO"""
-        if key not in self.__leaf_map.keys():
+        if key not in cls.__leaf_map.keys():
             return
-        if key + 1 in self.__leaf_map.keys():
-            self.__push_down(key + 1)
+        if key + 1 in cls.__leaf_map.keys():
+            cls.__push_down(key + 1)
         # delete entry under current id
-        value = self.__leaf_map.pop(key)
-        self.__leaf_map[key + 1] = value
+        value = cls.__leaf_map.pop(key)
+        cls.__leaf_map[key + 1] = value
 
     @classmethod
     def __next_key(cls, start: Optional[int] = None) -> id:
@@ -187,7 +187,7 @@ class AutoLeaf:
             key = start
 
         # find next best available value
-        while key in self.__leaf_map.keys():
+        while key in cls.__leaf_map.keys():
             key += 1
 
         return key
@@ -259,15 +259,15 @@ class AutoLeaf:
     @classmethod
     def is_registered(cls, module) -> bool:
         """TODO"""
-        return module in list(self.__leaf_map.values())
+        return module in list(cls.__leaf_map.values())
 
     @classmethod
     def infer(cls, signatures: List[Tuple[List[Union[MetaType, FeatureType, Type[FeatureType]]], Scope]]) -> Union[Module, None]:  # type: ignore
         """TODO"""
-        keys = sorted(list(self.__leaf_map.keys()))
+        keys = sorted(list(cls.__leaf_map.keys()))
 
         for key in keys:
-            if self.__leaf_map[key].accepts(signatures):
-                return self.__leaf_map[key]
+            if cls.__leaf_map[key].accepts(signatures):
+                return cls.__leaf_map[key]
 
         return None

--- a/src/spflow/torch/structure/autoleaf.py
+++ b/src/spflow/torch/structure/autoleaf.py
@@ -194,7 +194,7 @@ class AutoLeaf:
 
     @classmethod
     def register(
-        self,
+        cls,
         module: Module,
         priority: Optional[int] = None,
         before: Optional[List[Module]] = None,
@@ -203,9 +203,9 @@ class AutoLeaf:
     ) -> None:
         """TODO"""
         # if module already registered it is registered again at bottom of priority list
-        for id, m in list(self.__leaf_map.items()):
+        for id, m in list(cls.__leaf_map.items()):
             if module == m:
-                del self.__leaf_map[id]
+                del cls.__leaf_map[id]
 
         if priority is None:
             start = 0
@@ -224,11 +224,11 @@ class AutoLeaf:
             else:
                 ValueError("TODO.")
 
-            priority = self.__next_key(start)
+            priority = cls.__next_key(start)
 
         if before is None:
             # right beneath largest value
-            before = max(self.__leaf_map.keys()) + 2
+            before = max(cls.__leaf_map.keys()) + 2
         else:
             before_ids = []
             for ref in before:
@@ -237,24 +237,24 @@ class AutoLeaf:
                     before_ids.append(ref)
                 else:
                     # reference is a module
-                    for k, m in self.__leaf_map.items():
+                    for k, m in cls.__leaf_map.items():
                         if m == ref:
                             before_ids.append(k)
             # take minimum value as lower bound
             before = (
                 min(before_ids)
                 if before_ids
-                else max(self.__leaf_map.keys()) + 2
+                else max(cls.__leaf_map.keys()) + 2
             )
 
         if priority < before:
             # use value preference
-            self.__push_down(priority)
-            self.__leaf_map[priority] = module
+            cls.__push_down(priority)
+            cls.__leaf_map[priority] = module
         else:
             # take value of lower bound
-            self.__push_down(before)
-            self.__leaf_map[before] = module
+            cls.__push_down(before)
+            cls.__leaf_map[before] = module
 
     @classmethod
     def is_registered(cls, module) -> bool:

--- a/src/spflow/torch/structure/autoleaf.py
+++ b/src/spflow/torch/structure/autoleaf.py
@@ -167,7 +167,7 @@ class AutoLeaf:
         return leaf_type.from_signatures(signatures)
 
     @classmethod
-    def __push_down(self, key) -> None:
+    def __push_down(cls, key) -> None:
         """TODO"""
         if key not in self.__leaf_map.keys():
             return
@@ -178,7 +178,7 @@ class AutoLeaf:
         self.__leaf_map[key + 1] = value
 
     @classmethod
-    def __next_key(self, start: Optional[int] = None) -> id:
+    def __next_key(cls, start: Optional[int] = None) -> id:
         """TODO"""
         if start is None:
             # start from beginning
@@ -257,12 +257,12 @@ class AutoLeaf:
             self.__leaf_map[before] = module
 
     @classmethod
-    def is_registered(self, module) -> bool:
+    def is_registered(cls, module) -> bool:
         """TODO"""
         return module in list(self.__leaf_map.values())
 
     @classmethod
-    def infer(self, signatures: List[Tuple[List[Union[MetaType, FeatureType, Type[FeatureType]]], Scope]]) -> Union[Module, None]:  # type: ignore
+    def infer(cls, signatures: List[Tuple[List[Union[MetaType, FeatureType, Type[FeatureType]]], Scope]]) -> Union[Module, None]:  # type: ignore
         """TODO"""
         keys = sorted(list(self.__leaf_map.keys()))
 

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/bernoulli.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/bernoulli.py
@@ -133,7 +133,7 @@ class BernoulliLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "BernoulliLayer":
         """Creates an instance from a specified signature.
 
@@ -143,7 +143,7 @@ class BernoulliLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'BernoulliLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/bernoulli.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/bernoulli.py
@@ -113,7 +113,7 @@ class BernoulliLayer(Module):
         self.set_params(p)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``BernoulliLayer`` can represent one or more univariate nodes with ``MetaType.discrete`` or ``BernoulliType`` domains.

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/binomial.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/binomial.py
@@ -122,7 +122,7 @@ class BinomialLayer(Module):
         self.set_params(n, p)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``BinomialLayer`` can represent one or more univariate nodes with ``BinomialType`` domains.

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/binomial.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/binomial.py
@@ -142,7 +142,7 @@ class BinomialLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "BinomialLayer":
         """Creates an instance from a specified signature.
 
@@ -152,7 +152,7 @@ class BinomialLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'BinomialLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_bernoulli.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_bernoulli.py
@@ -132,7 +132,7 @@ class CondBernoulliLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondBernoulliLayer":
         """Creates an instance from a specified signature.
 
@@ -142,7 +142,7 @@ class CondBernoulliLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondBernoulliLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_bernoulli.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_bernoulli.py
@@ -112,7 +112,7 @@ class CondBernoulliLayer(Module):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondBernoulliLayer`` can represent one or more univariate nodes with ``MetaType.Discrete`` or ``BernoulliType`` domains.

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_binomial.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_binomial.py
@@ -125,7 +125,7 @@ class CondBinomialLayer(Module):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondBinomialLayer`` can represent one or more univariate nodes with ``BinomialType`` domains.

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_binomial.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_binomial.py
@@ -145,7 +145,7 @@ class CondBinomialLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondBinomialLayer":
         """Creates an instance from a specified signature.
 
@@ -155,7 +155,7 @@ class CondBinomialLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondBinomialLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_exponential.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_exponential.py
@@ -110,7 +110,7 @@ class CondExponentialLayer(Module):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondExponentialLayer`` can represent one or more univariate nodes with ``MetaType.Continuous`` or ``ExponentialType`` domains.

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_exponential.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_exponential.py
@@ -130,7 +130,7 @@ class CondExponentialLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondExponentialLayer":
         """Creates an instance from a specified signature.
 
@@ -140,7 +140,7 @@ class CondExponentialLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondExponentialLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_gamma.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_gamma.py
@@ -112,7 +112,7 @@ class CondGammaLayer(Module):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondGammaLayer`` can represent one or more univariate nodes with ``MetaType.Continuous`` or ``GammaType`` domains.

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_gamma.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_gamma.py
@@ -132,7 +132,7 @@ class CondGammaLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondGammaLayer":
         """Creates an instance from a specified signature.
 
@@ -142,7 +142,7 @@ class CondGammaLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondGammaLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_gaussian.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_gaussian.py
@@ -110,7 +110,7 @@ class CondGaussianLayer(Module):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondGaussianLayer`` can represent one or more univariate nodes with ``MetaType.Continuous`` or ``GaussianType`` domains.

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_gaussian.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_gaussian.py
@@ -130,7 +130,7 @@ class CondGaussianLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondGaussianLayer":
         """Creates an instance from a specified signature.
 
@@ -140,7 +140,7 @@ class CondGaussianLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondGaussianLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_geometric.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_geometric.py
@@ -109,7 +109,7 @@ class CondGeometricLayer(Module):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondGeometricLayer`` can represent one or more univariate nodes with ``MetaType.Discrete`` or ``GeometricType`` domains.

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_geometric.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_geometric.py
@@ -129,7 +129,7 @@ class CondGeometricLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondGeometricLayer":
         """Creates an instance from a specified signature.
 
@@ -139,7 +139,7 @@ class CondGeometricLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondGeometricLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_log_normal.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_log_normal.py
@@ -130,7 +130,7 @@ class CondLogNormalLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondLogNormalLayer":
         """Creates an instance from a specified signature.
 
@@ -140,7 +140,7 @@ class CondLogNormalLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondLogNormalLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_log_normal.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_log_normal.py
@@ -110,7 +110,7 @@ class CondLogNormalLayer(Module):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondLogNormalLayer`` can represent one or more univariate nodes with ``MetaType.Continuous`` or ``LogNormalType`` domains.

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_multivariate_gaussian.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_multivariate_gaussian.py
@@ -127,7 +127,7 @@ class CondMultivariateGaussianLayer(Module):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondMultivariateGaussianLayer`` can represent one or more multivariate nodes with ``MetaType.Continuous`` or ``GammaType`` domains.

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_multivariate_gaussian.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_multivariate_gaussian.py
@@ -147,7 +147,7 @@ class CondMultivariateGaussianLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondMultivariateGaussianLayer":
         """Creates an instance from a specified signature.
 
@@ -157,7 +157,7 @@ class CondMultivariateGaussianLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondMultivariateGaussianLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_negative_binomial.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_negative_binomial.py
@@ -121,7 +121,7 @@ class CondNegativeBinomialLayer(Module):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondNegativeBinomial`` can represent one or more univariate nodes with ``NegativeBinomialType`` domains.

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_negative_binomial.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_negative_binomial.py
@@ -141,7 +141,7 @@ class CondNegativeBinomialLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondNegativeBinomialLayer":
         """Creates an instance from a specified signature.
 
@@ -151,7 +151,7 @@ class CondNegativeBinomialLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondNegativeBinomialLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_poisson.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_poisson.py
@@ -129,7 +129,7 @@ class CondPoissonLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondPoissonLayer":
         """Creates an instance from a specified signature.
 
@@ -139,7 +139,7 @@ class CondPoissonLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondPoissonLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_poisson.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_poisson.py
@@ -109,7 +109,7 @@ class CondPoissonLayer(Module):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondPoissonLayer`` can represent one or more univariate nodes with ``MetaType.Discrete`` or ``PoissonType`` domains.

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/exponential.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/exponential.py
@@ -133,7 +133,7 @@ class ExponentialLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "ExponentialLayer":
         """Creates an instance from a specified signature.
 
@@ -143,7 +143,7 @@ class ExponentialLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'ExponentialLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/exponential.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/exponential.py
@@ -113,7 +113,7 @@ class ExponentialLayer(Module):
         self.set_params(l)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``ExponentialLayer`` can represent one or more univariate nodes with ``MetaType.Continuous`` or ``ExponentialType`` domains.

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/gamma.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/gamma.py
@@ -149,7 +149,7 @@ class GammaLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'GammaLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/gamma.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/gamma.py
@@ -121,7 +121,7 @@ class GammaLayer(Module):
         self.set_params(alpha, beta)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``GammaLayer`` can represent one or more univariate nodes with ``MetaType.Continuous`` or ``GammaType`` domains.
@@ -140,7 +140,7 @@ class GammaLayer(Module):
         return True
 
     @classmethod
-    def from_signatures(self, signatures: List[FeatureContext]) -> "GammaLayer":
+    def from_signatures(cls, signatures: List[FeatureContext]) -> "GammaLayer":
         """Creates an instance from a specified signature.
 
         Returns:

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/gaussian.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/gaussian.py
@@ -121,7 +121,7 @@ class GaussianLayer(Module):
         self.set_params(mean, std)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``GaussianLayer`` can represent one or more univariate nodes with ``MetaType.Continuous`` or ``GaussianType`` domains.

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/gaussian.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/gaussian.py
@@ -141,7 +141,7 @@ class GaussianLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "GaussianLayer":
         """Creates an instance from a specified signature.
 
@@ -151,7 +151,7 @@ class GaussianLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'GaussianLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/geometric.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/geometric.py
@@ -112,7 +112,7 @@ class GeometricLayer(Module):
         self.set_params(p)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``GeometricLayer`` can represent one or more univariate nodes with ``MetaType.Discrete`` or ``GeometricType`` domains.

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/geometric.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/geometric.py
@@ -132,7 +132,7 @@ class GeometricLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "GeometricLayer":
         """Creates an instance from a specified signature.
 
@@ -142,7 +142,7 @@ class GeometricLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'GeometricLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/hypergeometric.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/hypergeometric.py
@@ -117,7 +117,7 @@ class HypergeometricLayer(Module):
         self.set_params(N, M, n)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``HypergeometricLayer`` can represent one or more univariate nodes with ``HypergeometricType`` domains.

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/hypergeometric.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/hypergeometric.py
@@ -137,7 +137,7 @@ class HypergeometricLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "HypergeometricLayer":
         """Creates an instance from a specified signature.
 
@@ -147,7 +147,7 @@ class HypergeometricLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'HypergeometricLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/log_normal.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/log_normal.py
@@ -121,7 +121,7 @@ class LogNormalLayer(Module):
         self.set_params(mean, std)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``LogNormalLayer`` can represent one or more univariate nodes with ``MetaType.Continuous`` or ``LogNormalType`` domains.

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/log_normal.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/log_normal.py
@@ -141,7 +141,7 @@ class LogNormalLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "LogNormalLayer":
         """Creates an instance from a specified signature.
 
@@ -151,7 +151,7 @@ class LogNormalLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'LogNormalLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/multivariate_gaussian.py
@@ -131,7 +131,7 @@ class MultivariateGaussianLayer(Module):
         self.set_params(mean, cov)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``MultivariateGaussianLayer`` can represent one or more multivariate nodes with ``MetaType.Continuous`` or ``GaussianType`` domains.

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/multivariate_gaussian.py
@@ -151,7 +151,7 @@ class MultivariateGaussianLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "MultivariateGaussianLayer":
         """Creates an instance from a specified signature.
 
@@ -161,7 +161,7 @@ class MultivariateGaussianLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'MultivariateGaussianLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/negative_binomial.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/negative_binomial.py
@@ -141,7 +141,7 @@ class NegativeBinomialLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "NegativeBinomialLayer":
         """Creates an instance from a specified signature.
 
@@ -151,7 +151,7 @@ class NegativeBinomialLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'NegativeBinomialLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/negative_binomial.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/negative_binomial.py
@@ -121,7 +121,7 @@ class NegativeBinomialLayer(Module):
         self.set_params(n, p)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``NegativeBinomialLayer`` can represent one or more univariate nodes ``NegativeBinomialType`` domains.

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/poisson.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/poisson.py
@@ -130,7 +130,7 @@ class PoissonLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "PoissonLayer":
         """Creates an instance from a specified signature.
 
@@ -140,7 +140,7 @@ class PoissonLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'PoissonLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/poisson.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/poisson.py
@@ -110,7 +110,7 @@ class PoissonLayer(Module):
         self.set_params(l)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``PoissonLayer`` can represent one or more univariate nodes with ``MetaType.Discrete`` or ``PoissonType`` domains.

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/uniform.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/uniform.py
@@ -136,7 +136,7 @@ class UniformLayer(Module):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "UniformLayer":
         """Creates an instance from a specified signature.
 
@@ -146,7 +146,7 @@ class UniformLayer(Module):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'UniformLayer' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/uniform.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/uniform.py
@@ -116,7 +116,7 @@ class UniformLayer(Module):
         self.set_params(start, end, support_outside)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``UniformLayer`` can represent one or more univariate nodes with ``UniformType`` domains.

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/bernoulli.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/bernoulli.py
@@ -148,7 +148,7 @@ class Bernoulli(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'Bernoulli' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/bernoulli.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/bernoulli.py
@@ -104,7 +104,7 @@ class Bernoulli(LeafNode):
         )
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``Bernoulli`` can represent a single univariate node with ``MetaType.Discrete`` or ``BernoulliType`` domain.
@@ -139,7 +139,7 @@ class Bernoulli(LeafNode):
         return True
 
     @classmethod
-    def from_signatures(self, signatures: List[FeatureContext]) -> "Bernoulli":
+    def from_signatures(cls, signatures: List[FeatureContext]) -> "Bernoulli":
         """Creates an instance from a specified signature.
 
         Returns:

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/binomial.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/binomial.py
@@ -107,7 +107,7 @@ class Binomial(LeafNode):
         self.p_aux.data = proj_bounded_to_real(torch.tensor(float(p)), lb=0.0, ub=1.0)  # type: ignore
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``Binomial`` can represent a single univariate node with ``BinomialType`` domain.
@@ -139,7 +139,7 @@ class Binomial(LeafNode):
         return True
 
     @classmethod
-    def from_signatures(self, signatures: List[FeatureContext]) -> "Binomial":
+    def from_signatures(cls, signatures: List[FeatureContext]) -> "Binomial":
         """Creates an instance from a specified signature.
 
         Returns:

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/binomial.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/binomial.py
@@ -148,7 +148,7 @@ class Binomial(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'Binomial' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_bernoulli.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_bernoulli.py
@@ -100,7 +100,7 @@ class CondBernoulli(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondBernoulli":
         """Creates an instance from a specified signature.
 
@@ -110,7 +110,7 @@ class CondBernoulli(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondBernoulli' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_bernoulli.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_bernoulli.py
@@ -64,7 +64,7 @@ class CondBernoulli(LeafNode):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondBernoulli`` can represent a single univariate node with ``MetaType.Discrete`` or ``BernoulliType`` domain.

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_binomial.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_binomial.py
@@ -78,7 +78,7 @@ class CondBinomial(LeafNode):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondBinomial`` can represent a single univariate node with ``BinomialType`` domain.

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_binomial.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_binomial.py
@@ -111,7 +111,7 @@ class CondBinomial(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondBinomial":
         """Creates an instance from a specified signature.
 
@@ -121,7 +121,7 @@ class CondBinomial(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondBinomial' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_exponential.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_exponential.py
@@ -100,7 +100,7 @@ class CondExponential(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondExponential":
         """Creates an instance from a specified signature.
 
@@ -110,7 +110,7 @@ class CondExponential(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondExponential' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_exponential.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_exponential.py
@@ -64,7 +64,7 @@ class CondExponential(LeafNode):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondExponential`` can represent a single univariate node with ``MetaType.Continuous`` or ``ExponentialType`` domain.

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_gamma.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_gamma.py
@@ -66,7 +66,7 @@ class CondGamma(LeafNode):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondGamma`` can represent a single univariate node with ``MetaType.Continuous`` or ``GammaType`` domain.
@@ -101,7 +101,7 @@ class CondGamma(LeafNode):
         return True
 
     @classmethod
-    def from_signatures(self, signatures: List[FeatureContext]) -> "CondGamma":
+    def from_signatures(cls, signatures: List[FeatureContext]) -> "CondGamma":
         """Creates an instance from a specified signature.
 
         Returns:

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_gamma.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_gamma.py
@@ -110,7 +110,7 @@ class CondGamma(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondGamma' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_gaussian.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_gaussian.py
@@ -100,7 +100,7 @@ class CondGaussian(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondGaussian":
         """Creates an instance from a specified signature.
 
@@ -110,7 +110,7 @@ class CondGaussian(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondGaussian' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_gaussian.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_gaussian.py
@@ -64,7 +64,7 @@ class CondGaussian(LeafNode):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondGaussian`` can represent a single univariate node with ``MetaType.Continuous`` or ``GamamType`` domain.

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_geometric.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_geometric.py
@@ -99,7 +99,7 @@ class CondGeometric(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondGeometric":
         """Creates an instance from a specified signature.
 
@@ -109,7 +109,7 @@ class CondGeometric(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondGeometric' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_geometric.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_geometric.py
@@ -63,7 +63,7 @@ class CondGeometric(LeafNode):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondGeometric`` can represent a single univariate node with ``MetaType.Discrete`` or ``GeometricType`` domain.

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_log_normal.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_log_normal.py
@@ -64,7 +64,7 @@ class CondLogNormal(LeafNode):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondLogNormal`` can represent a single univariate node with ``MetaType.Continuous`` or ``LogNormalType`` domain.

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_log_normal.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_log_normal.py
@@ -100,7 +100,7 @@ class CondLogNormal(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondLogNormal":
         """Creates an instance from a specified signature.
 
@@ -110,7 +110,7 @@ class CondLogNormal(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondLogNormal' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_multivariate_gaussian.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_multivariate_gaussian.py
@@ -126,7 +126,7 @@ class CondMultivariateGaussian(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondMultivariateGaussian":
         """Creates an instance from a specified signature.
 
@@ -136,7 +136,7 @@ class CondMultivariateGaussian(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondMultivariateGaussian' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_multivariate_gaussian.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_multivariate_gaussian.py
@@ -87,7 +87,7 @@ class CondMultivariateGaussian(LeafNode):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondMultivariateGaussian`` can represent a single multivariate node with ``MetaType.Continuous`` or ``GaussianType`` domains.

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_negative_binomial.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_negative_binomial.py
@@ -110,7 +110,7 @@ class CondNegativeBinomial(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondNegativeBinomial":
         """Creates an instance from a specified signature.
 
@@ -120,7 +120,7 @@ class CondNegativeBinomial(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondNegativeBinomial' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_negative_binomial.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_negative_binomial.py
@@ -77,7 +77,7 @@ class CondNegativeBinomial(LeafNode):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondNegativeBinomial`` can represent a single univariate node with ``NegativeBinomialType`` domain.

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_poisson.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_poisson.py
@@ -99,7 +99,7 @@ class CondPoisson(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "CondPoisson":
         """Creates an instance from a specified signature.
 
@@ -109,7 +109,7 @@ class CondPoisson(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'CondPoisson' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_poisson.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_poisson.py
@@ -63,7 +63,7 @@ class CondPoisson(LeafNode):
         self.set_cond_f(cond_f)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``CondPoisson`` can represent a single univariate node with ``MetaType.Discrete`` or ``PoissonType`` domain.

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/exponential.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/exponential.py
@@ -117,7 +117,7 @@ class Exponential(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "Exponential":
         """Creates an instance from a specified signature.
 
@@ -127,7 +127,7 @@ class Exponential(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'Exponential' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/exponential.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/exponential.py
@@ -81,7 +81,7 @@ class Exponential(LeafNode):
         return proj_real_to_bounded(self.l_aux, lb=0.0)  # type: ignore
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``Exponential`` can represent a single univariate node with ``MetaType.Continuous`` or ``ExponentialType`` domain.

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/gamma.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/gamma.py
@@ -99,7 +99,7 @@ class Gamma(LeafNode):
         return proj_real_to_bounded(self.beta_aux, lb=0.0)  # type: ignore
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``Gamma`` can represent a single univariate node with ``MetaType.Continuous`` or ``GammaType`` domain.
@@ -134,7 +134,7 @@ class Gamma(LeafNode):
         return True
 
     @classmethod
-    def from_signatures(self, signatures: List[FeatureContext]) -> "Gamma":
+    def from_signatures(cls, signatures: List[FeatureContext]) -> "Gamma":
         """Creates an instance from a specified signature.
 
         Returns:

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/gamma.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/gamma.py
@@ -143,7 +143,7 @@ class Gamma(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'Gamma' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/gaussian.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/gaussian.py
@@ -90,7 +90,7 @@ class Gaussian(LeafNode):
         return proj_real_to_bounded(self.std_aux, lb=0.0)  # type: ignore
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``Gaussian`` can represent a single univariate node with ``MetaType.Continuous`` or ``GaussianType`` domain.
@@ -125,7 +125,7 @@ class Gaussian(LeafNode):
         return True
 
     @classmethod
-    def from_signatures(self, signatures: List[FeatureContext]) -> "Gaussian":
+    def from_signatures(cls, signatures: List[FeatureContext]) -> "Gaussian":
         """Creates an instance from a specified signature.
 
         Returns:

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/gaussian.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/gaussian.py
@@ -134,7 +134,7 @@ class Gaussian(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'Gaussian' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/geometric.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/geometric.py
@@ -124,7 +124,7 @@ class Geometric(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'Geometric' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/geometric.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/geometric.py
@@ -80,7 +80,7 @@ class Geometric(LeafNode):
         return proj_real_to_bounded(self.p_aux, lb=0.0, ub=1.0)  # type: ignore
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``Geometric`` can represent a single univariate node with ``MetaType.Discrete`` or ``GeometricType`` domain.
@@ -115,7 +115,7 @@ class Geometric(LeafNode):
         return True
 
     @classmethod
-    def from_signatures(self, signatures: List[FeatureContext]) -> "Geometric":
+    def from_signatures(cls, signatures: List[FeatureContext]) -> "Geometric":
         """Creates an instance from a specified signature.
 
         Returns:

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/hypergeometric.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/hypergeometric.py
@@ -76,7 +76,7 @@ class Hypergeometric(LeafNode):
         self.set_params(N, M, n)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``Hypergeometric`` can represent a single univariate node with ``HypergeometricType`` domain.

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/hypergeometric.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/hypergeometric.py
@@ -109,7 +109,7 @@ class Hypergeometric(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "Hypergeometric":
         """Creates an instance from a specified signature.
 
@@ -119,7 +119,7 @@ class Hypergeometric(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'Hypergeometric' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/log_normal.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/log_normal.py
@@ -93,7 +93,7 @@ class LogNormal(LeafNode):
         return proj_real_to_bounded(self.std_aux, lb=0.0)  # type: ignore
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``LogNormal`` can represent a single univariate node with ``MetaType.Continuous`` or ``LogNormalType`` domain.
@@ -128,7 +128,7 @@ class LogNormal(LeafNode):
         return True
 
     @classmethod
-    def from_signatures(self, signatures: List[FeatureContext]) -> "LogNormal":
+    def from_signatures(cls, signatures: List[FeatureContext]) -> "LogNormal":
         """Creates an instance from a specified signature.
 
         Returns:

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/log_normal.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/log_normal.py
@@ -137,7 +137,7 @@ class LogNormal(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'LogNormal' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/multivariate_gaussian.py
@@ -181,7 +181,7 @@ class MultivariateGaussian(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "MultivariateGaussian":
         """Creates an instance from a specified signature.
 
@@ -191,7 +191,7 @@ class MultivariateGaussian(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'MultivariateGaussian' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/multivariate_gaussian.py
@@ -142,7 +142,7 @@ class MultivariateGaussian(LeafNode):
         return torch.matmul(L, L.T)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``MultivariateGaussian`` can represent a single univariate node with ``MetaType.Continuous`` or ``GaussianType`` domains.

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/negative_binomial.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/negative_binomial.py
@@ -88,7 +88,7 @@ class NegativeBinomial(LeafNode):
         return proj_real_to_bounded(self.p_aux, lb=0.0, ub=1.0)  # type: ignore
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``NegativeBinomial`` can represent a single univariate node with ``NegativeBinomialType`` domain.

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/negative_binomial.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/negative_binomial.py
@@ -121,7 +121,7 @@ class NegativeBinomial(LeafNode):
 
     @classmethod
     def from_signatures(
-        self, signatures: List[FeatureContext]
+        cls, signatures: List[FeatureContext]
     ) -> "NegativeBinomial":
         """Creates an instance from a specified signature.
 
@@ -131,7 +131,7 @@ class NegativeBinomial(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'NegativeBinomial' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/poisson.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/poisson.py
@@ -80,7 +80,7 @@ class Poisson(LeafNode):
         return proj_real_to_bounded(self.l_aux, lb=0.0)  # type: ignore
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``Poisson`` can represent a single univariate node with ``MetaType.Discrete`` or ``PoissonType`` domain.
@@ -115,7 +115,7 @@ class Poisson(LeafNode):
         return True
 
     @classmethod
-    def from_signatures(self, signatures: List[FeatureContext]) -> "Poisson":
+    def from_signatures(cls, signatures: List[FeatureContext]) -> "Poisson":
         """Creates an instance from a specified signature.
 
         Returns:

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/poisson.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/poisson.py
@@ -124,7 +124,7 @@ class Poisson(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'Poisson' cannot be instantiated from the following signatures: {signatures}."
             )

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/uniform.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/uniform.py
@@ -87,7 +87,7 @@ class Uniform(LeafNode):
         self.set_params(start, end, support_outside)
 
     @classmethod
-    def accepts(self, signatures: List[FeatureContext]) -> bool:
+    def accepts(cls, signatures: List[FeatureContext]) -> bool:
         """Checks if a specified signature can be represented by the module.
 
         ``Uniform`` can represent a single univariate node with with ``UniformType`` domain.
@@ -119,7 +119,7 @@ class Uniform(LeafNode):
         return True
 
     @classmethod
-    def from_signatures(self, signatures: List[FeatureContext]) -> "Uniform":
+    def from_signatures(cls, signatures: List[FeatureContext]) -> "Uniform":
         """Creates an instance from a specified signature.
 
         Returns:

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/uniform.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/uniform.py
@@ -128,7 +128,7 @@ class Uniform(LeafNode):
         Raises:
             Signatures not accepted by the module.
         """
-        if not self.accepts(signatures):
+        if not cls.accepts(signatures):
             raise ValueError(
                 f"'Uniform' cannot be instantiated from the following signatures: {signatures}."
             )


### PR DESCRIPTION
I was a bit confused by some coding conventions:

```python
    @classmethod
    def accepts(self, signatures: List[FeatureContext]) -> bool:
```

Normally, I'd expect a `classmethod` to accept `cls` (short for class, not an actual instance yet) instead of `self` (which is more like this in other languages, i.e. a concrete instance).

This is quite common, i.e. run `git ls-files | xargs grep -Pzo "(?s)@classmethod\\s+ def (\w|_)+\\(self" --color`. Yes, I am aware that this is just convention. But I think it is a very useful one in Python. :stuck_out_tongue_closed_eyes: 

Specifically, the PR replaces `@classmethod\s*\n\s+def (\w|_)+\()self` with `$1cls`.