### PR TITLE
Run pyupgrade

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from os import path
 import setuptools  # type: ignore
 
-with open("../requirements.txt", "r") as fh:
+with open("../requirements.txt") as fh:
     requirements = fh.readlines()
 
 setuptools.setup(

--- a/src/spflow/base/inference/general/layers/leaves/parametric/bernoulli.py
+++ b/src/spflow/base/inference/general/layers/leaves/parametric/bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``BernoulliLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/inference/general/layers/leaves/parametric/binomial.py
+++ b/src/spflow/base/inference/general/layers/leaves/parametric/binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``BinomialLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/inference/general/layers/leaves/parametric/cond_bernoulli.py
+++ b/src/spflow/base/inference/general/layers/leaves/parametric/cond_bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondBernoulliLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/inference/general/layers/leaves/parametric/cond_binomial.py
+++ b/src/spflow/base/inference/general/layers/leaves/parametric/cond_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondBinomialLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/inference/general/layers/leaves/parametric/cond_exponential.py
+++ b/src/spflow/base/inference/general/layers/leaves/parametric/cond_exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondExponentialLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/inference/general/layers/leaves/parametric/cond_gamma.py
+++ b/src/spflow/base/inference/general/layers/leaves/parametric/cond_gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondGammaLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/inference/general/layers/leaves/parametric/cond_gaussian.py
+++ b/src/spflow/base/inference/general/layers/leaves/parametric/cond_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondGaussianLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/inference/general/layers/leaves/parametric/cond_geometric.py
+++ b/src/spflow/base/inference/general/layers/leaves/parametric/cond_geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondGeometricLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/inference/general/layers/leaves/parametric/cond_log_normal.py
+++ b/src/spflow/base/inference/general/layers/leaves/parametric/cond_log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondLogNormalLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/inference/general/layers/leaves/parametric/cond_multivariate_gaussian.py
+++ b/src/spflow/base/inference/general/layers/leaves/parametric/cond_multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondMultivariateGaussianLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/inference/general/layers/leaves/parametric/cond_negative_binomial.py
+++ b/src/spflow/base/inference/general/layers/leaves/parametric/cond_negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondNegativeBinomialLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/inference/general/layers/leaves/parametric/cond_poisson.py
+++ b/src/spflow/base/inference/general/layers/leaves/parametric/cond_poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondPoissonLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/inference/general/layers/leaves/parametric/exponential.py
+++ b/src/spflow/base/inference/general/layers/leaves/parametric/exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``ExponentialLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/inference/general/layers/leaves/parametric/gamma.py
+++ b/src/spflow/base/inference/general/layers/leaves/parametric/gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``GammaLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/inference/general/layers/leaves/parametric/gaussian.py
+++ b/src/spflow/base/inference/general/layers/leaves/parametric/gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``GaussianLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/inference/general/layers/leaves/parametric/geometric.py
+++ b/src/spflow/base/inference/general/layers/leaves/parametric/geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``GeometricLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/inference/general/layers/leaves/parametric/hypergeometric.py
+++ b/src/spflow/base/inference/general/layers/leaves/parametric/hypergeometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``HypergeometricLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/inference/general/layers/leaves/parametric/log_normal.py
+++ b/src/spflow/base/inference/general/layers/leaves/parametric/log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``LogNormalLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/inference/general/layers/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/base/inference/general/layers/leaves/parametric/multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``MultivariateGaussianLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/inference/general/layers/leaves/parametric/negative_binomial.py
+++ b/src/spflow/base/inference/general/layers/leaves/parametric/negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``NegativeBinomialLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/inference/general/layers/leaves/parametric/poisson.py
+++ b/src/spflow/base/inference/general/layers/leaves/parametric/poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``PoissonLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/inference/general/layers/leaves/parametric/uniform.py
+++ b/src/spflow/base/inference/general/layers/leaves/parametric/uniform.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``UniformLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/inference/general/nodes/leaves/parametric/bernoulli.py
+++ b/src/spflow/base/inference/general/nodes/leaves/parametric/bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``Bernoulli`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/general/nodes/leaves/parametric/binomial.py
+++ b/src/spflow/base/inference/general/nodes/leaves/parametric/binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``Binomial`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/general/nodes/leaves/parametric/cond_bernoulli.py
+++ b/src/spflow/base/inference/general/nodes/leaves/parametric/cond_bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondBernoulli`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/general/nodes/leaves/parametric/cond_binomial.py
+++ b/src/spflow/base/inference/general/nodes/leaves/parametric/cond_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondBinomial`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/general/nodes/leaves/parametric/cond_exponential.py
+++ b/src/spflow/base/inference/general/nodes/leaves/parametric/cond_exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondExponential`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/general/nodes/leaves/parametric/cond_gamma.py
+++ b/src/spflow/base/inference/general/nodes/leaves/parametric/cond_gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondGamma`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/general/nodes/leaves/parametric/cond_gaussian.py
+++ b/src/spflow/base/inference/general/nodes/leaves/parametric/cond_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondGaussian`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/general/nodes/leaves/parametric/cond_geometric.py
+++ b/src/spflow/base/inference/general/nodes/leaves/parametric/cond_geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondGeometric`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/general/nodes/leaves/parametric/cond_log_normal.py
+++ b/src/spflow/base/inference/general/nodes/leaves/parametric/cond_log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondLogNormal`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/general/nodes/leaves/parametric/cond_multivariate_gaussian.py
+++ b/src/spflow/base/inference/general/nodes/leaves/parametric/cond_multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondMultivariateGaussian`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/general/nodes/leaves/parametric/cond_negative_binomial.py
+++ b/src/spflow/base/inference/general/nodes/leaves/parametric/cond_negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondNegativeBinomial`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/general/nodes/leaves/parametric/cond_poisson.py
+++ b/src/spflow/base/inference/general/nodes/leaves/parametric/cond_poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondPoisson`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/general/nodes/leaves/parametric/exponential.py
+++ b/src/spflow/base/inference/general/nodes/leaves/parametric/exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``Exponential`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/general/nodes/leaves/parametric/gamma.py
+++ b/src/spflow/base/inference/general/nodes/leaves/parametric/gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``Gamma`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/general/nodes/leaves/parametric/gaussian.py
+++ b/src/spflow/base/inference/general/nodes/leaves/parametric/gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``Gaussian`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/general/nodes/leaves/parametric/geometric.py
+++ b/src/spflow/base/inference/general/nodes/leaves/parametric/geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``Geometric`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/general/nodes/leaves/parametric/hypergeometric.py
+++ b/src/spflow/base/inference/general/nodes/leaves/parametric/hypergeometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``Hypergeometric`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/general/nodes/leaves/parametric/log_normal.py
+++ b/src/spflow/base/inference/general/nodes/leaves/parametric/log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``LogNormal`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/general/nodes/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/base/inference/general/nodes/leaves/parametric/multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``MultivariateGaussian`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/general/nodes/leaves/parametric/negative_binomial.py
+++ b/src/spflow/base/inference/general/nodes/leaves/parametric/negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``NegativeBinomial`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/general/nodes/leaves/parametric/poisson.py
+++ b/src/spflow/base/inference/general/nodes/leaves/parametric/poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``Poisson`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/general/nodes/leaves/parametric/uniform.py
+++ b/src/spflow/base/inference/general/nodes/leaves/parametric/uniform.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``Uniform`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/module.py
+++ b/src/spflow/base/inference/module.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``Module`` objects for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/inference/nested_module.py
+++ b/src/spflow/base/inference/nested_module.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``NestedModule`` objects for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/inference/spn/layers/cond_sum_layer.py
+++ b/src/spflow/base/inference/spn/layers/cond_sum_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for SPN-like conditional sum layers for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/spn/layers/hadamard_layer.py
+++ b/src/spflow/base/inference/spn/layers/hadamard_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for SPN-like Hadamard layer for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/inference/spn/layers/partition_layer.py
+++ b/src/spflow/base/inference/spn/layers/partition_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for SPN-like partition layer for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/inference/spn/layers/product_layer.py
+++ b/src/spflow/base/inference/spn/layers/product_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for SPN-like product layer for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/inference/spn/layers/sum_layer.py
+++ b/src/spflow/base/inference/spn/layers/sum_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for SPN-like sum layer for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/inference/spn/nodes/cond_sum_node.py
+++ b/src/spflow/base/inference/spn/nodes/cond_sum_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for SPN-like conditional sum nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/base/inference/spn/nodes/product_node.py
+++ b/src/spflow/base/inference/spn/nodes/product_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for SPN-like product nodes for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/inference/spn/nodes/sum_node.py
+++ b/src/spflow/base/inference/spn/nodes/sum_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for SPN-like sum nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/inference/spn/rat/rat_spn.py
+++ b/src/spflow/base/inference/spn/rat/rat_spn.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for RAT-SPNs for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/learning/general/layers/leaves/parametric/bernoulli.py
+++ b/src/spflow/base/learning/general/layers/leaves/parametric/bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``BernoulliLayer`` leaves for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/general/layers/leaves/parametric/binomial.py
+++ b/src/spflow/base/learning/general/layers/leaves/parametric/binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``BinomialLayer`` leaves for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/general/layers/leaves/parametric/exponential.py
+++ b/src/spflow/base/learning/general/layers/leaves/parametric/exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``ExponentialLayer`` leaves for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/general/layers/leaves/parametric/gamma.py
+++ b/src/spflow/base/learning/general/layers/leaves/parametric/gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``GammaLayer`` leaves for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/general/layers/leaves/parametric/gaussian.py
+++ b/src/spflow/base/learning/general/layers/leaves/parametric/gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``GaussianLayer`` leaves for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/general/layers/leaves/parametric/geometric.py
+++ b/src/spflow/base/learning/general/layers/leaves/parametric/geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``GeometricLayer`` leaves for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/general/layers/leaves/parametric/hypergeometric.py
+++ b/src/spflow/base/learning/general/layers/leaves/parametric/hypergeometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``HypergeometricLayer`` leaves for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/general/layers/leaves/parametric/log_normal.py
+++ b/src/spflow/base/learning/general/layers/leaves/parametric/log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``LogNormalLayer`` leaves for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/general/layers/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/base/learning/general/layers/leaves/parametric/multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``MultivariateGaussianLayer`` leaves for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/general/layers/leaves/parametric/negative_binomial.py
+++ b/src/spflow/base/learning/general/layers/leaves/parametric/negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``NegativeBinomialLayer`` leaves for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/general/layers/leaves/parametric/poisson.py
+++ b/src/spflow/base/learning/general/layers/leaves/parametric/poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``PoissonLayer`` leaves for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/general/layers/leaves/parametric/uniform.py
+++ b/src/spflow/base/learning/general/layers/leaves/parametric/uniform.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``UniformLayer`` leaves for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/general/nodes/leaves/parametric/bernoulli.py
+++ b/src/spflow/base/learning/general/nodes/leaves/parametric/bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``Bernoulli`` nodes for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/general/nodes/leaves/parametric/binomial.py
+++ b/src/spflow/base/learning/general/nodes/leaves/parametric/binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``Binomial`` nodes for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/general/nodes/leaves/parametric/exponential.py
+++ b/src/spflow/base/learning/general/nodes/leaves/parametric/exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``Exponential`` nodes for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/general/nodes/leaves/parametric/gamma.py
+++ b/src/spflow/base/learning/general/nodes/leaves/parametric/gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``Gamma`` nodes for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/general/nodes/leaves/parametric/gaussian.py
+++ b/src/spflow/base/learning/general/nodes/leaves/parametric/gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``Gaussian`` nodes for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/general/nodes/leaves/parametric/geometric.py
+++ b/src/spflow/base/learning/general/nodes/leaves/parametric/geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``Geometric`` nodes for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/general/nodes/leaves/parametric/hypergeometric.py
+++ b/src/spflow/base/learning/general/nodes/leaves/parametric/hypergeometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``Hypergeometric`` nodes for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/general/nodes/leaves/parametric/log_normal.py
+++ b/src/spflow/base/learning/general/nodes/leaves/parametric/log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``LogNormal`` nodes for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/general/nodes/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/base/learning/general/nodes/leaves/parametric/multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``MultivariateGaussian`` nodes for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/general/nodes/leaves/parametric/negative_binomial.py
+++ b/src/spflow/base/learning/general/nodes/leaves/parametric/negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``NegativeBinomial`` nodes for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/general/nodes/leaves/parametric/poisson.py
+++ b/src/spflow/base/learning/general/nodes/leaves/parametric/poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``Poisson`` nodes for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/general/nodes/leaves/parametric/uniform.py
+++ b/src/spflow/base/learning/general/nodes/leaves/parametric/uniform.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``Uniform`` nodes for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/base/learning/spn/learn_spn/learn_spn.py
+++ b/src/spflow/base/learning/spn/learn_spn/learn_spn.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains the LearnSPN structure and parameter learner for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/sampling/general/layers/leaves/parametric/bernoulli.py
+++ b/src/spflow/base/sampling/general/layers/leaves/parametric/bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``BernoulliLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/sampling/general/layers/leaves/parametric/binomial.py
+++ b/src/spflow/base/sampling/general/layers/leaves/parametric/binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``BinomialLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/sampling/general/layers/leaves/parametric/cond_bernoulli.py
+++ b/src/spflow/base/sampling/general/layers/leaves/parametric/cond_bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondBernoulliLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/sampling/general/layers/leaves/parametric/cond_binomial.py
+++ b/src/spflow/base/sampling/general/layers/leaves/parametric/cond_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondBinomialLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/sampling/general/layers/leaves/parametric/cond_exponential.py
+++ b/src/spflow/base/sampling/general/layers/leaves/parametric/cond_exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondExponentialLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/sampling/general/layers/leaves/parametric/cond_gamma.py
+++ b/src/spflow/base/sampling/general/layers/leaves/parametric/cond_gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondGammaLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/sampling/general/layers/leaves/parametric/cond_gaussian.py
+++ b/src/spflow/base/sampling/general/layers/leaves/parametric/cond_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondGaussianLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/sampling/general/layers/leaves/parametric/cond_geometric.py
+++ b/src/spflow/base/sampling/general/layers/leaves/parametric/cond_geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondGeometricLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/sampling/general/layers/leaves/parametric/cond_log_normal.py
+++ b/src/spflow/base/sampling/general/layers/leaves/parametric/cond_log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondLogNormalLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/sampling/general/layers/leaves/parametric/cond_multivariate_gaussian.py
+++ b/src/spflow/base/sampling/general/layers/leaves/parametric/cond_multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondMultivariateGaussianLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/sampling/general/layers/leaves/parametric/cond_negative_binomial.py
+++ b/src/spflow/base/sampling/general/layers/leaves/parametric/cond_negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondNegativeBinomialLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/sampling/general/layers/leaves/parametric/cond_poisson.py
+++ b/src/spflow/base/sampling/general/layers/leaves/parametric/cond_poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondPoissonLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/sampling/general/layers/leaves/parametric/exponential.py
+++ b/src/spflow/base/sampling/general/layers/leaves/parametric/exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``ExponentialLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/sampling/general/layers/leaves/parametric/gamma.py
+++ b/src/spflow/base/sampling/general/layers/leaves/parametric/gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``GammaLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/sampling/general/layers/leaves/parametric/gaussian.py
+++ b/src/spflow/base/sampling/general/layers/leaves/parametric/gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``GaussianLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/sampling/general/layers/leaves/parametric/geometric.py
+++ b/src/spflow/base/sampling/general/layers/leaves/parametric/geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``GeometricLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/sampling/general/layers/leaves/parametric/hypergeometric.py
+++ b/src/spflow/base/sampling/general/layers/leaves/parametric/hypergeometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``HypergeometricLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/sampling/general/layers/leaves/parametric/log_normal.py
+++ b/src/spflow/base/sampling/general/layers/leaves/parametric/log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``LogNormalLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/sampling/general/layers/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/base/sampling/general/layers/leaves/parametric/multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``MultivariateGaussianLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/sampling/general/layers/leaves/parametric/negative_binomial.py
+++ b/src/spflow/base/sampling/general/layers/leaves/parametric/negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``NegativeBinomialLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/sampling/general/layers/leaves/parametric/poisson.py
+++ b/src/spflow/base/sampling/general/layers/leaves/parametric/poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``PoissonLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/sampling/general/layers/leaves/parametric/uniform.py
+++ b/src/spflow/base/sampling/general/layers/leaves/parametric/uniform.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``UniformLayer`` leaves for SPFlow in the ``base`` backend.
 """
 import numpy as np

--- a/src/spflow/base/sampling/general/nodes/leaves/parametric/bernoulli.py
+++ b/src/spflow/base/sampling/general/nodes/leaves/parametric/bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``Bernoulli`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/general/nodes/leaves/parametric/binomial.py
+++ b/src/spflow/base/sampling/general/nodes/leaves/parametric/binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``Binomial`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/general/nodes/leaves/parametric/cond_bernoulli.py
+++ b/src/spflow/base/sampling/general/nodes/leaves/parametric/cond_bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondBernoulli`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/general/nodes/leaves/parametric/cond_binomial.py
+++ b/src/spflow/base/sampling/general/nodes/leaves/parametric/cond_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondBinomial`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/general/nodes/leaves/parametric/cond_exponential.py
+++ b/src/spflow/base/sampling/general/nodes/leaves/parametric/cond_exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondExponential`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/general/nodes/leaves/parametric/cond_gamma.py
+++ b/src/spflow/base/sampling/general/nodes/leaves/parametric/cond_gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondGamma`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/general/nodes/leaves/parametric/cond_gaussian.py
+++ b/src/spflow/base/sampling/general/nodes/leaves/parametric/cond_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondGaussian`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/general/nodes/leaves/parametric/cond_geometric.py
+++ b/src/spflow/base/sampling/general/nodes/leaves/parametric/cond_geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondGeometric`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/general/nodes/leaves/parametric/cond_log_normal.py
+++ b/src/spflow/base/sampling/general/nodes/leaves/parametric/cond_log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondLogNormal`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/general/nodes/leaves/parametric/cond_multivariate_gaussian.py
+++ b/src/spflow/base/sampling/general/nodes/leaves/parametric/cond_multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondMultivariateGaussian`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/general/nodes/leaves/parametric/cond_negative_binomial.py
+++ b/src/spflow/base/sampling/general/nodes/leaves/parametric/cond_negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondNegativeBinomial`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/general/nodes/leaves/parametric/cond_poisson.py
+++ b/src/spflow/base/sampling/general/nodes/leaves/parametric/cond_poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondPoisson`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/general/nodes/leaves/parametric/exponential.py
+++ b/src/spflow/base/sampling/general/nodes/leaves/parametric/exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``Exponential`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/general/nodes/leaves/parametric/gamma.py
+++ b/src/spflow/base/sampling/general/nodes/leaves/parametric/gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``Gamma`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/general/nodes/leaves/parametric/gaussian.py
+++ b/src/spflow/base/sampling/general/nodes/leaves/parametric/gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``Gaussian`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/general/nodes/leaves/parametric/geometric.py
+++ b/src/spflow/base/sampling/general/nodes/leaves/parametric/geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``Geometric`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/general/nodes/leaves/parametric/hypergeometric.py
+++ b/src/spflow/base/sampling/general/nodes/leaves/parametric/hypergeometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``Hypergeometric`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/general/nodes/leaves/parametric/log_normal.py
+++ b/src/spflow/base/sampling/general/nodes/leaves/parametric/log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``LogNormal`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/general/nodes/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/base/sampling/general/nodes/leaves/parametric/multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``MultivariateGaussian`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/general/nodes/leaves/parametric/negative_binomial.py
+++ b/src/spflow/base/sampling/general/nodes/leaves/parametric/negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``NegativeBinomial`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/general/nodes/leaves/parametric/poisson.py
+++ b/src/spflow/base/sampling/general/nodes/leaves/parametric/poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``Poisson`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/general/nodes/leaves/parametric/uniform.py
+++ b/src/spflow/base/sampling/general/nodes/leaves/parametric/uniform.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``Uniform`` nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/module.py
+++ b/src/spflow/base/sampling/module.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``Module`` for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/nested_module.py
+++ b/src/spflow/base/sampling/nested_module.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``NestedModule`` for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/spn/layers/cond_sum_layer.py
+++ b/src/spflow/base/sampling/spn/layers/cond_sum_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for conditional SPN-like sum layers for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/spn/layers/hadamard_layer.py
+++ b/src/spflow/base/sampling/spn/layers/hadamard_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for SPN-like Hadamard layers for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/spn/layers/partition_layer.py
+++ b/src/spflow/base/sampling/spn/layers/partition_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for SPN-like partition layers for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/spn/layers/product_layer.py
+++ b/src/spflow/base/sampling/spn/layers/product_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for SPN-like product layers for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/spn/layers/sum_layer.py
+++ b/src/spflow/base/sampling/spn/layers/sum_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for SPN-like sum layers for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/spn/nodes/cond_sum_node.py
+++ b/src/spflow/base/sampling/spn/nodes/cond_sum_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for conditional SPN-like sum nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/spn/nodes/product_node.py
+++ b/src/spflow/base/sampling/spn/nodes/product_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for SPN-like product nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/spn/nodes/sum_node.py
+++ b/src/spflow/base/sampling/spn/nodes/sum_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for SPN-like sum nodes for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/sampling/spn/rat/rat_spn.py
+++ b/src/spflow/base/sampling/spn/rat/rat_spn.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for RAT-SPNs for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/base/structure/autoleaf.py
+++ b/src/spflow/base/structure/autoleaf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """TODO
 """
 from typing import Tuple, List, Union, Optional, Dict, Type

--- a/src/spflow/base/structure/general/layers/leaves/parametric/bernoulli.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Bernoulli leaf layer for SPFlow in the ``base`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple
@@ -80,7 +79,7 @@ class BernoulliLayer(Module):
 
             self._n_out = len(scope)
 
-        super(BernoulliLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # create leaf nodes
         self.nodes = [Bernoulli(s) for s in scope]

--- a/src/spflow/base/structure/general/layers/leaves/parametric/binomial.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Binomial leaf layer for SPFlow in the ``base`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Type
@@ -87,7 +86,7 @@ class BinomialLayer(Module):
 
             self._n_out = len(scope)
 
-        super(BinomialLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # create leaf nodes
         self.nodes = [Binomial(s, 1, 0.5) for s in scope]

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_bernoulli.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Bernoulli leaf layer for SPFlow in the ``base`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Callable, Type
@@ -90,7 +89,7 @@ class CondBernoulliLayer(Module):
 
             self._n_out = len(scope)
 
-        super(CondBernoulliLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # create leaf nodes
         self.nodes = [CondBernoulli(s) for s in scope]

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_binomial.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Binomial leaf layer for SPFlow in the ``base`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Callable, Type
@@ -98,7 +97,7 @@ class CondBinomialLayer(Module):
 
             self._n_out = len(scope)
 
-        super(CondBinomialLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # create leaf nodes
         self.nodes = [CondBinomial(s, 1) for s in scope]

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_exponential.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Exponential leaf layer for SPFlow in the ``base`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Callable, Type
@@ -88,7 +87,7 @@ class CondExponentialLayer(Module):
 
             self._n_out = len(scope)
 
-        super(CondExponentialLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # create leaf nodes
         self.nodes = [CondExponential(s) for s in scope]

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_gamma.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Gamma leaf layer for SPFlow in the ``base`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Callable, Type
@@ -90,7 +89,7 @@ class CondGammaLayer(Module):
 
             self._n_out = len(scope)
 
-        super(CondGammaLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # create leaf nodes
         self.nodes = [CondGamma(s) for s in scope]

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_gaussian.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Gaussian leaf layer for SPFlow in the 'base' backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Callable, Type
@@ -88,7 +87,7 @@ class CondGaussianLayer(Module):
 
             self._n_out = len(scope)
 
-        super(CondGaussianLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # create leaf nodes
         self.nodes = [CondGaussian(s) for s in scope]

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_geometric.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Geometric leaf layer for SPFlow in the ``base`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Callable, Type
@@ -87,7 +86,7 @@ class CondGeometricLayer(Module):
 
             self._n_out = len(scope)
 
-        super(CondGeometricLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # create leaf nodes
         self.nodes = [CondGeometric(s) for s in scope]

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_log_normal.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Log-Normal leaf layer for SPFlow in the ``base`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Callable, Type
@@ -88,7 +87,7 @@ class CondLogNormalLayer(Module):
 
             self._n_out = len(scope)
 
-        super(CondLogNormalLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # create leaf nodes
         self.nodes = [CondLogNormal(s) for s in scope]

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_multivariate_gaussian.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Multivariate Gaussian leaf layer for SPFlow in the ``base`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Callable, Type
@@ -102,7 +101,7 @@ class CondMultivariateGaussianLayer(Module):
 
             self._n_out = len(scope)
 
-        super(CondMultivariateGaussianLayer, self).__init__(
+        super().__init__(
             children=[], **kwargs
         )
 

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_negative_binomial.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Negative Binomial leaf layer for SPFlow in the ``base`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Callable, Type
@@ -94,7 +93,7 @@ class CondNegativeBinomialLayer(Module):
 
             self._n_out = len(scope)
 
-        super(CondNegativeBinomialLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # create leaf nodes
         self.nodes = [CondNegativeBinomial(s, 1) for s in scope]

--- a/src/spflow/base/structure/general/layers/leaves/parametric/cond_poisson.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/cond_poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Poisson leaf layer for SPFlow in the ``base`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Callable, Type
@@ -87,7 +86,7 @@ class CondPoissonLayer(Module):
 
             self._n_out = len(scope)
 
-        super(CondPoissonLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # create leaf nodes
         self.nodes = [CondPoisson(s) for s in scope]

--- a/src/spflow/base/structure/general/layers/leaves/parametric/exponential.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Exponential leaf layer for SPFlow in the ``base`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Type
@@ -80,7 +79,7 @@ class ExponentialLayer(Module):
 
             self._n_out = len(scope)
 
-        super(ExponentialLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # create leaf nodes
         self.nodes = [Exponential(s) for s in scope]

--- a/src/spflow/base/structure/general/layers/leaves/parametric/gamma.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Gamma leaf layer for SPFlow in the ``base`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Type
@@ -85,7 +84,7 @@ class GammaLayer(Module):
 
             self._n_out = len(scope)
 
-        super(GammaLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # create leaf nodes
         self.nodes = [Gamma(s) for s in scope]

--- a/src/spflow/base/structure/general/layers/leaves/parametric/gaussian.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Gaussian leaf layer for SPFlow in the ``base`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Type
@@ -87,7 +86,7 @@ class GaussianLayer(Module):
 
             self._n_out = len(scope)
 
-        super(GaussianLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # create leaf nodes
         self.nodes = [Gaussian(s, 0.0, 1.0) for s in scope]

--- a/src/spflow/base/structure/general/layers/leaves/parametric/geometric.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Geometric leaf layer for SPFlow in the ``base`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Type
@@ -79,7 +78,7 @@ class GeometricLayer(Module):
 
             self._n_out = len(scope)
 
-        super(GeometricLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # create leaf nodes
         self.nodes = [Geometric(s) for s in scope]

--- a/src/spflow/base/structure/general/layers/leaves/parametric/hypergeometric.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/hypergeometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Hypergeometric leaf layer for SPFlow in the ``base`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Type
@@ -93,7 +92,7 @@ class HypergeometricLayer(Module):
 
             self._n_out = len(scope)
 
-        super(HypergeometricLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # create leaf nodes
         self.nodes = [Hypergeometric(s, 1, 1, 1) for s in scope]

--- a/src/spflow/base/structure/general/layers/leaves/parametric/log_normal.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Log-Normal leaf layer for SPFlow in the ``base`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Type
@@ -87,7 +86,7 @@ class LogNormalLayer(Module):
 
             self._n_out = len(scope)
 
-        super(LogNormalLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # create leaf nodes
         self.nodes = [LogNormal(s, 0.0, 1.0) for s in scope]

--- a/src/spflow/base/structure/general/layers/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Multivariate Gaussian leaf layer for SPFlow in the ``base`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Type
@@ -99,7 +98,7 @@ class MultivariateGaussianLayer(Module):
 
             self._n_out = len(scope)
 
-        super(MultivariateGaussianLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         if mean is None:
             mean = [np.zeros(len(s.query)) for s in scope]

--- a/src/spflow/base/structure/general/layers/leaves/parametric/negative_binomial.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Negative Binomial leaf layer for SPFlow in the ``base`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Type
@@ -86,7 +85,7 @@ class NegativeBinomialLayer(Module):
 
             self._n_out = len(scope)
 
-        super(NegativeBinomialLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # create leaf nodes
         self.nodes = [NegativeBinomial(s, 1, 0.5) for s in scope]

--- a/src/spflow/base/structure/general/layers/leaves/parametric/poisson.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Poisson leaf layer for SPFlow in the ``base`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Type
@@ -77,7 +76,7 @@ class PoissonLayer(Module):
 
             self._n_out = len(scope)
 
-        super(PoissonLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # create leaf nodes
         self.nodes = [Poisson(s) for s in scope]

--- a/src/spflow/base/structure/general/layers/leaves/parametric/uniform.py
+++ b/src/spflow/base/structure/general/layers/leaves/parametric/uniform.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Uniform leaf node for SPFlow in the ``base`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Type
@@ -81,7 +80,7 @@ class UniformLayer(Module):
 
             self._n_out = len(scope)
 
-        super(UniformLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # create leaf nodes
         self.nodes = [Uniform(s, 0.0, 1.0) for s in scope]

--- a/src/spflow/base/structure/general/nodes/leaf_node.py
+++ b/src/spflow/base/structure/general/nodes/leaf_node.py
@@ -27,6 +27,6 @@ class LeafNode(Node, ABC):
             scope:
                 Scope object representing the scope of the leaf node,
         """
-        super(LeafNode, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         self.scope = scope

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/bernoulli.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Bernoulli leaf node for SPFlow in the ``base`` backend.
 """
 from typing import Tuple, List
@@ -53,7 +52,7 @@ class Bernoulli(LeafNode):
                 f"Evidence scope for 'Bernoulli' should be empty, but was {scope.evidence}."
             )
 
-        super(Bernoulli, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # set parameters
         self.set_params(p)

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/binomial.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Binomial leaf node for SPFlow in the ``base`` backend.
 """
 from typing import Tuple, List
@@ -55,7 +54,7 @@ class Binomial(LeafNode):
                 f"Evidence scope for 'Binomial' should be empty, but was {scope.evidence}."
             )
 
-        super(Binomial, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # set parameters
         self.set_params(n, p)

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_bernoulli.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Bernoulli leaf node for SPFlow in the ``base`` backend.
 """
 from typing import Tuple, Optional, Callable, Union, List
@@ -54,7 +53,7 @@ class CondBernoulli(LeafNode):
                 f"Evidence scope for 'CondBernoulli' should not be empty."
             )
 
-        super(CondBernoulli, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # set optional conditional function
         self.set_cond_f(cond_f)

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_binomial.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Binomial leaf node for SPFlow in the ``base`` backend.
 """
 from typing import Tuple, Optional, Callable, Union, List
@@ -61,7 +60,7 @@ class CondBinomial(LeafNode):
                 f"Evidence scope for 'CondBinomial' should not be empty."
             )
 
-        super(CondBinomial, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # set non-conditional parameters
         self.set_params(n)

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_exponential.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Exponential leaf node for SPFlow in the ``base`` backend.
 """
 from typing import Tuple, Optional, Callable, Union, List
@@ -54,7 +53,7 @@ class CondExponential(LeafNode):
                 f"Evidence scope for 'CondExponential' should not be empty."
             )
 
-        super(CondExponential, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # set optional conditional function
         self.set_cond_f(cond_f)

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_gamma.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Gamma leaf node for SPFlow in the ``base`` backend.
 """
 from typing import Tuple, Optional, Callable, Union, List
@@ -56,7 +55,7 @@ class CondGamma(LeafNode):
                 f"Evidence scope for 'CondGamma' should not be empty."
             )
 
-        super(CondGamma, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # set optional conditional function
         self.set_cond_f(cond_f)

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_gaussian.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Gaussian leaf node for SPFlow in the ``base`` backend.
 """
 from typing import Tuple, Optional, Callable, Union, List
@@ -58,7 +57,7 @@ class CondGaussian(LeafNode):
                 f"Evidence scope for 'CondGaussian' should not be empty."
             )
 
-        super(CondGaussian, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # set optional conditional function
         self.set_cond_f(cond_f)

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_geometric.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Geometric leaf node for SPFlow in the ``base`` backend.
 """
 from typing import Tuple, Optional, Callable, Union, List
@@ -53,7 +52,7 @@ class CondGeometric(LeafNode):
                 f"Evidence scope for 'CondGeometric' should not be empty."
             )
 
-        super(CondGeometric, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # set optional conditional function
         self.set_cond_f(cond_f)

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_log_normal.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Log-Normal leaf node for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Tuple, Callable, Union, List
@@ -54,7 +53,7 @@ class CondLogNormal(LeafNode):
                 f"Evidence scope for LogNormal should not be empty."
             )
 
-        super(CondLogNormal, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # set optional conditional function
         self.set_cond_f(cond_f)

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_multivariate_gaussian.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Multivariate Normal leaf node for SPFlow in the ``base`` backend.
 """
 from typing import Tuple, List, Union, Optional, Iterable, Union, Callable
@@ -77,7 +76,7 @@ class CondMultivariateGaussian(LeafNode):
                 "Size of query scope for 'CondMultivariateGaussian' must be at least 1."
             )
 
-        super(CondMultivariateGaussian, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # set optional conditional function
         self.set_cond_f(cond_f)

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_negative_binomial.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Negative Binomial leaf node for SPFlow in the ``base`` backend.
 """
 from typing import Tuple, Optional, Callable, Union, List
@@ -60,7 +59,7 @@ class CondNegativeBinomial(LeafNode):
                 f"Evidence scope for 'CondNegativeBinomial' should be empty."
             )
 
-        super(CondNegativeBinomial, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # set non-conditional parameters
         self.set_params(n)

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/cond_poisson.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/cond_poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Poisson leaf node for SPFlow in the ``base`` backend.
 """
 from typing import Tuple, Optional, Callable, Union, List
@@ -53,7 +52,7 @@ class CondPoisson(LeafNode):
                 f"Evidence scope for 'CondPoisson' should be empty."
             )
 
-        super(CondPoisson, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # set optional conditional function
         self.set_cond_f(cond_f)

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/exponential.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Exponential leaf node for SPFlow in the ``base`` backend.
 """
 from typing import Tuple, List
@@ -50,7 +49,7 @@ class Exponential(LeafNode):
                 f"Evidence scope for 'Exponential' should be empty, but was {scope.evidence}."
             )
 
-        super(Exponential, self).__init__(scope=scope)
+        super().__init__(scope=scope)
         self.set_params(l)
 
     @classmethod

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/gamma.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Gamma leaf node for SPFlow in the ``base`` backend.
 """
 from typing import Tuple, List
@@ -62,7 +61,7 @@ class Gamma(LeafNode):
                 f"Evidence scope for 'Gamma' should be empty, but was {scope.evidence}."
             )
 
-        super(Gamma, self).__init__(scope=scope)
+        super().__init__(scope=scope)
         self.set_params(alpha, beta)
 
     @classmethod

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/gaussian.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Gaussian leaf node for SPFlow in the ``base`` backend.
 """
 from typing import Tuple, List
@@ -60,7 +59,7 @@ class Gaussian(LeafNode):
                 f"Evidence scope for 'Gaussian' should be empty, but was {scope.evidence}."
             )
 
-        super(Gaussian, self).__init__(scope=scope)
+        super().__init__(scope=scope)
         self.set_params(mean, std)
 
     @classmethod

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/geometric.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Geometric leaf node for SPFlow in the ``base`` backend.
 """
 from typing import Tuple, List
@@ -49,7 +48,7 @@ class Geometric(LeafNode):
                 f"Evidence scope for 'Geometric' should be empty, but was {scope.evidence}."
             )
 
-        super(Geometric, self).__init__(scope=scope)
+        super().__init__(scope=scope)
         self.set_params(p)
 
     @classmethod

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/hypergeometric.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/hypergeometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Hypergeometric leaf node for SPFlow in the ``base`` backend.
 """
 from typing import Tuple, List
@@ -59,7 +58,7 @@ class Hypergeometric(LeafNode):
                 f"Evidence scope for 'Hypergeometric' should be empty, but was {scope.evidence}."
             )
 
-        super(Hypergeometric, self).__init__(scope=scope)
+        super().__init__(scope=scope)
         self.set_params(N, M, n)
 
     @classmethod

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/log_normal.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Log-Normal leaf node for SPFlow in the ``base`` backend.
 """
 from typing import Tuple, List
@@ -59,7 +58,7 @@ class LogNormal(LeafNode):
                 f"Evidence scope for 'LogNormal' should be empty, but was {scope.evidence}."
             )
 
-        super(LogNormal, self).__init__(scope=scope)
+        super().__init__(scope=scope)
         self.set_params(mean, std)
 
     @classmethod

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Multivariate Normal leaf node for SPFlow in the ``base`` backend.
 """
 from typing import Tuple, List, Union, Optional, Iterable
@@ -76,7 +75,7 @@ class MultivariateGaussian(LeafNode):
                 "Size of query scope for 'MultivariateGaussian' must be at least 1."
             )
 
-        super(MultivariateGaussian, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         if mean is None:
             mean = np.zeros((1, len(scope.query)))

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/negative_binomial.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Negative Binomial leaf node for SPFlow in the ``base`` backend.
 """
 from typing import Tuple, List
@@ -54,7 +53,7 @@ class NegativeBinomial(LeafNode):
                 f"Evidence scope for 'NegativeBinomial' should be empty, but was {scope.evidence}."
             )
 
-        super(NegativeBinomial, self).__init__(scope=scope)
+        super().__init__(scope=scope)
         self.set_params(n, p)
 
     @classmethod

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/poisson.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Poisson leaf node for SPFlow in the ``base`` backend.
 """
 from typing import Tuple, List
@@ -49,7 +48,7 @@ class Poisson(LeafNode):
                 f"Evidence scope for 'Poisson' should be empty, but was {scope.evidence}."
             )
 
-        super(Poisson, self).__init__(scope=scope)
+        super().__init__(scope=scope)
         self.set_params(l)
 
     @classmethod

--- a/src/spflow/base/structure/general/nodes/leaves/parametric/uniform.py
+++ b/src/spflow/base/structure/general/nodes/leaves/parametric/uniform.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Uniform leaf node for SPFlow in the ``base`` backend.
 """
 from typing import Tuple, List
@@ -63,7 +62,7 @@ class Uniform(LeafNode):
                 f"Evidence scope for 'Uniform' should be empty, but was {scope.evidence}."
             )
 
-        super(Uniform, self).__init__(scope=scope)
+        super().__init__(scope=scope)
         self.set_params(start, end, support_outside)
 
     @classmethod

--- a/src/spflow/base/structure/general/nodes/node.py
+++ b/src/spflow/base/structure/general/nodes/node.py
@@ -43,7 +43,7 @@ class Node(Module, ABC):
         if children is None:
             children = []
 
-        super(Node, self).__init__(children=children, **kwargs)
+        super().__init__(children=children, **kwargs)
 
     @property
     def n_out(self) -> int:

--- a/src/spflow/base/structure/module.py
+++ b/src/spflow/base/structure/module.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains the abstract ``Module`` class for SPFlow modules in the ``base`` backend.
 
 All valid SPFlow modules in the ``base`` backend should inherit from this class or a subclass of it.

--- a/src/spflow/base/structure/nested_module.py
+++ b/src/spflow/base/structure/nested_module.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains the abstract ``NestedModule`` class for SPFlow modules in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import DispatchContext
@@ -35,7 +34,7 @@ class NestedModule(Module, ABC):
         if children is None:
             children = []
 
-        super(NestedModule, self).__init__(children=children, **kwargs)
+        super().__init__(children=children, **kwargs)
         self.placeholders = []
 
     def create_placeholder(self, input_ids: List[int]) -> "Placeholder":

--- a/src/spflow/base/structure/spn/layers/cond_sum_layer.py
+++ b/src/spflow/base/structure/spn/layers/cond_sum_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional SPN-like sum layer for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch
@@ -76,7 +75,7 @@ class CondSumLayer(NestedModule):
                 "'CondSumLayer' requires at least one child to be specified."
             )
 
-        super(CondSumLayer, self).__init__(children=children, **kwargs)
+        super().__init__(children=children, **kwargs)
 
         self._n_out = n_nodes
         self.n_in = sum(child.n_out for child in self.children)

--- a/src/spflow/base/structure/spn/layers/hadamard_layer.py
+++ b/src/spflow/base/structure/spn/layers/hadamard_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains SPN-like hadamard layer for SPFlow in the ``base`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -120,7 +119,7 @@ class HadamardLayer(NestedModule):
                     "Scopes of partitions must be pair-wise disjoint."
                 )
 
-        super(HadamardLayer, self).__init__(
+        super().__init__(
             children=sum(child_partitions, []), **kwargs
         )
 

--- a/src/spflow/base/structure/spn/layers/partition_layer.py
+++ b/src/spflow/base/structure/spn/layers/partition_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains SPN-like partition layer for SPFlow in the ``base`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -113,7 +112,7 @@ class PartitionLayer(NestedModule):
                     "Scopes of partitions must be pair-wise disjoint."
                 )
 
-        super(PartitionLayer, self).__init__(
+        super().__init__(
             children=sum(child_partitions, []), **kwargs
         )
 

--- a/src/spflow/base/structure/spn/layers/product_layer.py
+++ b/src/spflow/base/structure/spn/layers/product_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains SPN-like product layer for SPFlow in the ``base`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -55,7 +54,7 @@ class ProductLayer(NestedModule):
                 "'ProductLayer' requires at least one child to be specified."
             )
 
-        super(ProductLayer, self).__init__(children=children, **kwargs)
+        super().__init__(children=children, **kwargs)
 
         # create input placeholder
         ph = self.create_placeholder(

--- a/src/spflow/base/structure/spn/layers/sum_layer.py
+++ b/src/spflow/base/structure/spn/layers/sum_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains SPN-like sum layer for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch
@@ -72,7 +71,7 @@ class SumLayer(NestedModule):
                 "'SumLayer' requires at least one child to be specified."
             )
 
-        super(SumLayer, self).__init__(children=children, **kwargs)
+        super().__init__(children=children, **kwargs)
 
         self._n_out = n_nodes
         self.n_in = sum(child.n_out for child in self.children)

--- a/src/spflow/base/structure/spn/nodes/cond_sum_node.py
+++ b/src/spflow/base/structure/spn/nodes/cond_sum_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional SPN-like sum node for SPFlow in the ``base`` backend.
 """
 from abc import ABC
@@ -52,7 +51,7 @@ class CondSumNode(Node):
         Raises:
             ValueError: Invalid arguments.
         """
-        super(CondSumNode, self).__init__(children=children)
+        super().__init__(children=children)
 
         if not children:
             raise ValueError(

--- a/src/spflow/base/structure/spn/nodes/product_node.py
+++ b/src/spflow/base/structure/spn/nodes/product_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains ``ProductNode`` for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch
@@ -38,7 +37,7 @@ class ProductNode(Node):
         Raises:
             ValueError: Invalid arguments.
         """
-        super(ProductNode, self).__init__(children=children)
+        super().__init__(children=children)
 
         if not children:
             raise ValueError(

--- a/src/spflow/base/structure/spn/nodes/sum_node.py
+++ b/src/spflow/base/structure/spn/nodes/sum_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains ``SumNode`` for SPFlow in the ``base`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch
@@ -48,7 +47,7 @@ class SumNode(Node):
         Raises:
             ValueError: Invalid arguments.
         """
-        super(SumNode, self).__init__(children=children)
+        super().__init__(children=children)
 
         if not children:
             raise ValueError(

--- a/src/spflow/base/structure/spn/rat/rat_spn.py
+++ b/src/spflow/base/structure/spn/rat/rat_spn.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains the SPFlow architecture for Random and Tensorized Sum-Product Networks (RAT-SPNs) in the ``base`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -67,7 +66,7 @@ class RatSPN(Module):
         n_region_nodes: int,
         n_leaf_nodes: int,
     ) -> None:
-        super(RatSPN, self).__init__(children=[])
+        super().__init__(children=[])
         r"""Initializer for ``RatSPN`` object.
 
         Args:

--- a/src/spflow/base/structure/spn/rat/region_graph.py
+++ b/src/spflow/base/structure/spn/rat/region_graph.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains classes and functions to create Region Graphs.
 """
 import random

--- a/src/spflow/base/utils/connected_components.py
+++ b/src/spflow/base/utils/connected_components.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Algorithm to find connected components in an undirected graph.
 
 Typical usage example:
@@ -45,7 +44,7 @@ def connected_components(adjacency_matrix: np.ndarray) -> List[Set[int]]:
 
         # perform breadth-first search
         visited = set()
-        active_set = set([vertices.pop()])
+        active_set = {vertices.pop()}
 
         # while there are previously unvisited vertices
         while active_set:

--- a/src/spflow/base/utils/empirical_cdf.py
+++ b/src/spflow/base/utils/empirical_cdf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Algorithm to compute the empirical cummulative distribution function (CDF) for input data.
 
 Typical usage example:

--- a/src/spflow/base/utils/nearest_sym_pd.py
+++ b/src/spflow/base/utils/nearest_sym_pd.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Algorithm to compute the closest positive definite matrix to a given matrix.
 
 Typical usage example:

--- a/src/spflow/base/utils/randomized_dependency_coefficients.py
+++ b/src/spflow/base/utils/randomized_dependency_coefficients.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Algorithm to compute randomized dependency coefficients (RDCs) for a data set.
 
 Typical usage example:

--- a/src/spflow/meta/data/feature_context.py
+++ b/src/spflow/meta/data/feature_context.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """TODO
 """
 from spflow.meta.data.scope import Scope

--- a/src/spflow/meta/data/feature_types.py
+++ b/src/spflow/meta/data/feature_types.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Feature types indicating the distribution or meta type of data features.
 """
 from spflow.meta.data.meta_type import MetaType

--- a/src/spflow/meta/data/meta_type.py
+++ b/src/spflow/meta/data/meta_type.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Meta types for data feature types.
 """
 from enum import Enum

--- a/src/spflow/meta/data/scope.py
+++ b/src/spflow/meta/data/scope.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains the ``Scope`` class for representing scopes over random variables.
 
 Typical usage example:

--- a/src/spflow/meta/dispatch/dispatch.py
+++ b/src/spflow/meta/dispatch/dispatch.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains the standard 'dispatch' decorator for SPFlow.
 
 Typical usage example:

--- a/src/spflow/meta/dispatch/dispatch_context.py
+++ b/src/spflow/meta/dispatch/dispatch_context.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains the dispatch context used in SPFlow
 
 Typical usage example:

--- a/src/spflow/meta/dispatch/memoize.py
+++ b/src/spflow/meta/dispatch/memoize.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains a convenient decorator to automatically check for cached values during dispatch.
 
 Typical usage example:

--- a/src/spflow/meta/dispatch/sampling_context.py
+++ b/src/spflow/meta/dispatch/sampling_context.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains the sampling context used in SPFlow
 
 Typical usage example:

--- a/src/spflow/meta/dispatch/substitutable.py
+++ b/src/spflow/meta/dispatch/substitutable.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains a convenient decorator to automatically check for alternative function during dispatch.
 
 Typical usage example:

--- a/src/spflow/meta/structure/module.py
+++ b/src/spflow/meta/structure/module.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains the abstract ``MetaModule`` class for SPFlow modules.
 
 All valid SPFlow modules should be a subclass of this class.

--- a/src/spflow/torch/inference/general/layers/leaves/parametric/bernoulli.py
+++ b/src/spflow/torch/inference/general/layers/leaves/parametric/bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``BernoulliLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/layers/leaves/parametric/binomial.py
+++ b/src/spflow/torch/inference/general/layers/leaves/parametric/binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``BinomialLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/layers/leaves/parametric/cond_bernoulli.py
+++ b/src/spflow/torch/inference/general/layers/leaves/parametric/cond_bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondBernoulliLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/layers/leaves/parametric/cond_binomial.py
+++ b/src/spflow/torch/inference/general/layers/leaves/parametric/cond_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-probability
 """Contains inference methods for ``CondBinomialLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/layers/leaves/parametric/cond_exponential.py
+++ b/src/spflow/torch/inference/general/layers/leaves/parametric/cond_exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondExponentialLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/layers/leaves/parametric/cond_gamma.py
+++ b/src/spflow/torch/inference/general/layers/leaves/parametric/cond_gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondGammaLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/layers/leaves/parametric/cond_gaussian.py
+++ b/src/spflow/torch/inference/general/layers/leaves/parametric/cond_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondGaussianLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/layers/leaves/parametric/cond_geometric.py
+++ b/src/spflow/torch/inference/general/layers/leaves/parametric/cond_geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondGeometricLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/layers/leaves/parametric/cond_log_normal.py
+++ b/src/spflow/torch/inference/general/layers/leaves/parametric/cond_log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondLogNormalLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/layers/leaves/parametric/cond_multivariate_gaussian.py
+++ b/src/spflow/torch/inference/general/layers/leaves/parametric/cond_multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondMultivariateGaussianLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/layers/leaves/parametric/cond_negative_binomial.py
+++ b/src/spflow/torch/inference/general/layers/leaves/parametric/cond_negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondNegativeBinomialLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/layers/leaves/parametric/cond_poisson.py
+++ b/src/spflow/torch/inference/general/layers/leaves/parametric/cond_poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondPoissonLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/layers/leaves/parametric/exponential.py
+++ b/src/spflow/torch/inference/general/layers/leaves/parametric/exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``ExponentialLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/layers/leaves/parametric/gamma.py
+++ b/src/spflow/torch/inference/general/layers/leaves/parametric/gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``GammaLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/layers/leaves/parametric/gaussian.py
+++ b/src/spflow/torch/inference/general/layers/leaves/parametric/gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``GaussianLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/layers/leaves/parametric/geometric.py
+++ b/src/spflow/torch/inference/general/layers/leaves/parametric/geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``GeometricLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/layers/leaves/parametric/hypergeometric.py
+++ b/src/spflow/torch/inference/general/layers/leaves/parametric/hypergeometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``HypergeometricLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/layers/leaves/parametric/log_normal.py
+++ b/src/spflow/torch/inference/general/layers/leaves/parametric/log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``LogNormalLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/layers/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/torch/inference/general/layers/leaves/parametric/multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``MultivariateGaussianLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/layers/leaves/parametric/negative_binomial.py
+++ b/src/spflow/torch/inference/general/layers/leaves/parametric/negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``NegativeBinomialLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/layers/leaves/parametric/poisson.py
+++ b/src/spflow/torch/inference/general/layers/leaves/parametric/poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``PoissonLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/layers/leaves/parametric/uniform.py
+++ b/src/spflow/torch/inference/general/layers/leaves/parametric/uniform.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``UniformLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/nodes/leaves/parametric/bernoulli.py
+++ b/src/spflow/torch/inference/general/nodes/leaves/parametric/bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``Bernoulli`` nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/nodes/leaves/parametric/binomial.py
+++ b/src/spflow/torch/inference/general/nodes/leaves/parametric/binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``Binomial`` nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/nodes/leaves/parametric/cond_bernoulli.py
+++ b/src/spflow/torch/inference/general/nodes/leaves/parametric/cond_bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondBernoulli`` nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/nodes/leaves/parametric/cond_binomial.py
+++ b/src/spflow/torch/inference/general/nodes/leaves/parametric/cond_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondBinomial`` nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/nodes/leaves/parametric/cond_exponential.py
+++ b/src/spflow/torch/inference/general/nodes/leaves/parametric/cond_exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondExponential`` nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/nodes/leaves/parametric/cond_gamma.py
+++ b/src/spflow/torch/inference/general/nodes/leaves/parametric/cond_gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondGamma`` nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/nodes/leaves/parametric/cond_gaussian.py
+++ b/src/spflow/torch/inference/general/nodes/leaves/parametric/cond_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondGaussian`` nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/nodes/leaves/parametric/cond_geometric.py
+++ b/src/spflow/torch/inference/general/nodes/leaves/parametric/cond_geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondGeometric`` nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/nodes/leaves/parametric/cond_log_normal.py
+++ b/src/spflow/torch/inference/general/nodes/leaves/parametric/cond_log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondLogNormal`` nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/nodes/leaves/parametric/cond_multivariate_gaussian.py
+++ b/src/spflow/torch/inference/general/nodes/leaves/parametric/cond_multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondMultivariateGaussian`` nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/nodes/leaves/parametric/cond_negative_binomial.py
+++ b/src/spflow/torch/inference/general/nodes/leaves/parametric/cond_negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondNegativeBinomial`` nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/nodes/leaves/parametric/cond_poisson.py
+++ b/src/spflow/torch/inference/general/nodes/leaves/parametric/cond_poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``CondPoisson`` nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/nodes/leaves/parametric/exponential.py
+++ b/src/spflow/torch/inference/general/nodes/leaves/parametric/exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``Exponential`` nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/nodes/leaves/parametric/gamma.py
+++ b/src/spflow/torch/inference/general/nodes/leaves/parametric/gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``Gamma`` nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/nodes/leaves/parametric/gaussian.py
+++ b/src/spflow/torch/inference/general/nodes/leaves/parametric/gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``Gaussian`` nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/nodes/leaves/parametric/geometric.py
+++ b/src/spflow/torch/inference/general/nodes/leaves/parametric/geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``Geometric`` nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/nodes/leaves/parametric/hypergeometric.py
+++ b/src/spflow/torch/inference/general/nodes/leaves/parametric/hypergeometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``Hypergeometric`` nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/nodes/leaves/parametric/log_normal.py
+++ b/src/spflow/torch/inference/general/nodes/leaves/parametric/log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``LogNormal`` nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/nodes/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/torch/inference/general/nodes/leaves/parametric/multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``MultivariateGaussian`` nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/nodes/leaves/parametric/negative_binomial.py
+++ b/src/spflow/torch/inference/general/nodes/leaves/parametric/negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``NegativeBinomial`` nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/nodes/leaves/parametric/poisson.py
+++ b/src/spflow/torch/inference/general/nodes/leaves/parametric/poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``Poisson`` nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/general/nodes/leaves/parametric/uniform.py
+++ b/src/spflow/torch/inference/general/nodes/leaves/parametric/uniform.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``Uniform`` nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/module.py
+++ b/src/spflow/torch/inference/module.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``Module`` objects for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import (

--- a/src/spflow/torch/inference/nested_module.py
+++ b/src/spflow/torch/inference/nested_module.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for ``NestedModule`` objects for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/inference/spn/layers/cond_sum_layer.py
+++ b/src/spflow/torch/inference/spn/layers/cond_sum_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for SPN-like conditional layers for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/spn/layers/hadamard_layer.py
+++ b/src/spflow/torch/inference/spn/layers/hadamard_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for SPN-like Hadamard layer for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/inference/spn/layers/partition_layer.py
+++ b/src/spflow/torch/inference/spn/layers/partition_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for SPN-like partition layer for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/inference/spn/layers/product_layer.py
+++ b/src/spflow/torch/inference/spn/layers/product_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for SPN-like product layer for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/inference/spn/layers/sum_layer.py
+++ b/src/spflow/torch/inference/spn/layers/sum_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for SPN-like sum layer for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/inference/spn/nodes/cond_sum_node.py
+++ b/src/spflow/torch/inference/spn/nodes/cond_sum_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for SPN-like conditional nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/spn/nodes/product_node.py
+++ b/src/spflow/torch/inference/spn/nodes/product_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for SPN-like product nodes for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/inference/spn/nodes/sum_node.py
+++ b/src/spflow/torch/inference/spn/nodes/sum_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for SPN-like sum nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/inference/spn/rat/rat_spn.py
+++ b/src/spflow/torch/inference/spn/rat/rat_spn.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains inference methods for RAT-SPNs for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/learning/expectation_maximization/expectation_maximization.py
+++ b/src/spflow/torch/learning/expectation_maximization/expectation_maximization.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains the expectation maximization optimization parameter learner for SPFlow in the ``torch`` backend.
 """
 from typing import List

--- a/src/spflow/torch/learning/general/layers/leaves/parametric/bernoulli.py
+++ b/src/spflow/torch/learning/general/layers/leaves/parametric/bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``BernoulliLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/general/layers/leaves/parametric/binomial.py
+++ b/src/spflow/torch/learning/general/layers/leaves/parametric/binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``BinomialLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/general/layers/leaves/parametric/exponential.py
+++ b/src/spflow/torch/learning/general/layers/leaves/parametric/exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``ExponentialLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/general/layers/leaves/parametric/gamma.py
+++ b/src/spflow/torch/learning/general/layers/leaves/parametric/gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``GammaLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/general/layers/leaves/parametric/gaussian.py
+++ b/src/spflow/torch/learning/general/layers/leaves/parametric/gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``GaussianLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/general/layers/leaves/parametric/geometric.py
+++ b/src/spflow/torch/learning/general/layers/leaves/parametric/geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``GeometricLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/general/layers/leaves/parametric/hypergeometric.py
+++ b/src/spflow/torch/learning/general/layers/leaves/parametric/hypergeometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``HypergeometricLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/general/layers/leaves/parametric/log_normal.py
+++ b/src/spflow/torch/learning/general/layers/leaves/parametric/log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``LogNormalLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/general/layers/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/torch/learning/general/layers/leaves/parametric/multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``MultivariateGaussianLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/general/layers/leaves/parametric/negative_binomial.py
+++ b/src/spflow/torch/learning/general/layers/leaves/parametric/negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``NegativeBinomialLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/general/layers/leaves/parametric/poisson.py
+++ b/src/spflow/torch/learning/general/layers/leaves/parametric/poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``PoissonLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/general/layers/leaves/parametric/uniform.py
+++ b/src/spflow/torch/learning/general/layers/leaves/parametric/uniform.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``UniformLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/general/nodes/leaves/parametric/bernoulli.py
+++ b/src/spflow/torch/learning/general/nodes/leaves/parametric/bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``Bernoulli`` nodes for SPFlow in the ``torch`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/general/nodes/leaves/parametric/binomial.py
+++ b/src/spflow/torch/learning/general/nodes/leaves/parametric/binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``Binomial`` nodes for SPFlow in the ``torch`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/general/nodes/leaves/parametric/exponential.py
+++ b/src/spflow/torch/learning/general/nodes/leaves/parametric/exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``Exponential`` nodes for SPFlow in the ``torch`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/general/nodes/leaves/parametric/gamma.py
+++ b/src/spflow/torch/learning/general/nodes/leaves/parametric/gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``Gamma`` nodes for SPFlow in the ``torch`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/general/nodes/leaves/parametric/gaussian.py
+++ b/src/spflow/torch/learning/general/nodes/leaves/parametric/gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``Gaussian`` nodes for SPFlow in the ``torch`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/general/nodes/leaves/parametric/geometric.py
+++ b/src/spflow/torch/learning/general/nodes/leaves/parametric/geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``Geometric`` nodes for SPFlow in the ``torch`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/general/nodes/leaves/parametric/hypergeometric.py
+++ b/src/spflow/torch/learning/general/nodes/leaves/parametric/hypergeometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``Hypergeometric`` nodes for SPFlow in the ``base`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/general/nodes/leaves/parametric/log_normal.py
+++ b/src/spflow/torch/learning/general/nodes/leaves/parametric/log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``LogNormal`` nodes for SPFlow in the ``torch`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/general/nodes/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/torch/learning/general/nodes/leaves/parametric/multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``MultivariateGaussian`` nodes for SPFlow in the ``torch`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/general/nodes/leaves/parametric/negative_binomial.py
+++ b/src/spflow/torch/learning/general/nodes/leaves/parametric/negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``NegativeBinomial`` nodes for SPFlow in the ``torch`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/general/nodes/leaves/parametric/poisson.py
+++ b/src/spflow/torch/learning/general/nodes/leaves/parametric/poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``Poisson`` nodes for SPFlow in the ``torch`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/general/nodes/leaves/parametric/uniform.py
+++ b/src/spflow/torch/learning/general/nodes/leaves/parametric/uniform.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for ``Uniform`` nodes for SPFlow in the ``torch`` backend.
 """
 from typing import Optional, Union, Callable

--- a/src/spflow/torch/learning/spn/layers/hadamard_layer.py
+++ b/src/spflow/torch/learning/spn/layers/hadamard_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for SPN-like Hadamard layers for SPFlow in the ``torch`` backend.
 """
 from typing import Optional

--- a/src/spflow/torch/learning/spn/layers/partition_layer.py
+++ b/src/spflow/torch/learning/spn/layers/partition_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for SPN-like partition layers for SPFlow in the ``torch`` backend.
 """
 from typing import Optional

--- a/src/spflow/torch/learning/spn/layers/product_layer.py
+++ b/src/spflow/torch/learning/spn/layers/product_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for SPN-like product layers for SPFlow in the ``torch`` backend.
 """
 from typing import Optional

--- a/src/spflow/torch/learning/spn/layers/sum_layer.py
+++ b/src/spflow/torch/learning/spn/layers/sum_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for SPN-like sum layers for SPFlow in the ``torch`` backend.
 """
 from typing import Optional

--- a/src/spflow/torch/learning/spn/learn_spn/learn_spn.py
+++ b/src/spflow/torch/learning/spn/learn_spn/learn_spn.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains the LearnSPN structure and parameter learner for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/learning/spn/nodes/product_node.py
+++ b/src/spflow/torch/learning/spn/nodes/product_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for SPN-like sum nodes for SPFlow in the ``torch`` backend.
 """
 from typing import Optional

--- a/src/spflow/torch/learning/spn/nodes/sum_node.py
+++ b/src/spflow/torch/learning/spn/nodes/sum_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for SPN-like sum nodes for SPFlow in the ``torch`` backend.
 """
 from typing import Optional

--- a/src/spflow/torch/learning/spn/rat/rat_spn.py
+++ b/src/spflow/torch/learning/spn/rat/rat_spn.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains learning methods for Random and Tensorized Sum-Product Networks (RAT-SPNs) for SPFlow in the ``torch`` backend.
 """
 from typing import Optional

--- a/src/spflow/torch/sampling/general/layers/leaves/parametric/bernoulli.py
+++ b/src/spflow/torch/sampling/general/layers/leaves/parametric/bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``BernoulliLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -64,9 +63,9 @@ def sample(
     if any([i >= data.shape[0] for i in sampling_ctx.instance_ids]):
         raise ValueError("Some instance ids are out of bounds for data tensor.")
 
-    unique_output_signatures = set(
+    unique_output_signatures = {
         frozenset(l) for l in sampling_ctx.output_ids
-    )
+    }
 
     # make sure that no scopes are overlapping
     # TODO: suppress check

--- a/src/spflow/torch/sampling/general/layers/leaves/parametric/binomial.py
+++ b/src/spflow/torch/sampling/general/layers/leaves/parametric/binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``BinomialLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -64,9 +63,9 @@ def sample(
     if any([i >= data.shape[0] for i in sampling_ctx.instance_ids]):
         raise ValueError("Some instance ids are out of bounds for data tensor.")
 
-    unique_output_signatures = set(
+    unique_output_signatures = {
         frozenset(l) for l in sampling_ctx.output_ids
-    )
+    }
 
     # make sure that no scopes are overlapping
     # TODO: suppress check

--- a/src/spflow/torch/sampling/general/layers/leaves/parametric/cond_bernoulli.py
+++ b/src/spflow/torch/sampling/general/layers/leaves/parametric/cond_bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondBernoulliLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -64,9 +63,9 @@ def sample(
     if any([i >= data.shape[0] for i in sampling_ctx.instance_ids]):
         raise ValueError("Some instance ids are out of bounds for data tensor.")
 
-    unique_output_signatures = set(
+    unique_output_signatures = {
         frozenset(l) for l in sampling_ctx.output_ids
-    )
+    }
 
     # retrieve value for 'p'
     p = layer.retrieve_params(data, dispatch_ctx)

--- a/src/spflow/torch/sampling/general/layers/leaves/parametric/cond_binomial.py
+++ b/src/spflow/torch/sampling/general/layers/leaves/parametric/cond_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondBinomialLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -64,9 +63,9 @@ def sample(
     if any([i >= data.shape[0] for i in sampling_ctx.instance_ids]):
         raise ValueError("Some instance ids are out of bounds for data tensor.")
 
-    unique_output_signatures = set(
+    unique_output_signatures = {
         frozenset(l) for l in sampling_ctx.output_ids
-    )
+    }
 
     # retrieve value for 'p'
     p = layer.retrieve_params(data, dispatch_ctx)

--- a/src/spflow/torch/sampling/general/layers/leaves/parametric/cond_exponential.py
+++ b/src/spflow/torch/sampling/general/layers/leaves/parametric/cond_exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondExponentialLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -64,9 +63,9 @@ def sample(
     if any([i >= data.shape[0] for i in sampling_ctx.instance_ids]):
         raise ValueError("Some instance ids are out of bounds for data tensor.")
 
-    unique_output_signatures = set(
+    unique_output_signatures = {
         frozenset(l) for l in sampling_ctx.output_ids
-    )
+    }
 
     # retrieve value for 'l'
     l = layer.retrieve_params(data, dispatch_ctx)

--- a/src/spflow/torch/sampling/general/layers/leaves/parametric/cond_gamma.py
+++ b/src/spflow/torch/sampling/general/layers/leaves/parametric/cond_gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondGammaLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -64,9 +63,9 @@ def sample(
     if any([i >= data.shape[0] for i in sampling_ctx.instance_ids]):
         raise ValueError("Some instance ids are out of bounds for data tensor.")
 
-    unique_output_signatures = set(
+    unique_output_signatures = {
         frozenset(l) for l in sampling_ctx.output_ids
-    )
+    }
 
     # retrieve values for 'alpha','beta'
     alpha, beta = layer.retrieve_params(data, dispatch_ctx)

--- a/src/spflow/torch/sampling/general/layers/leaves/parametric/cond_gaussian.py
+++ b/src/spflow/torch/sampling/general/layers/leaves/parametric/cond_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondGaussianLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -64,9 +63,9 @@ def sample(
     if any([i >= data.shape[0] for i in sampling_ctx.instance_ids]):
         raise ValueError("Some instance ids are out of bounds for data tensor.")
 
-    unique_output_signatures = set(
+    unique_output_signatures = {
         frozenset(l) for l in sampling_ctx.output_ids
-    )
+    }
 
     # retrieve values for 'mean','std'
     mean, std = layer.retrieve_params(data, dispatch_ctx)

--- a/src/spflow/torch/sampling/general/layers/leaves/parametric/cond_geometric.py
+++ b/src/spflow/torch/sampling/general/layers/leaves/parametric/cond_geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondGeometricLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -64,9 +63,9 @@ def sample(
     if any([i >= data.shape[0] for i in sampling_ctx.instance_ids]):
         raise ValueError("Some instance ids are out of bounds for data tensor.")
 
-    unique_output_signatures = set(
+    unique_output_signatures = {
         frozenset(l) for l in sampling_ctx.output_ids
-    )
+    }
 
     # retrieve value for 'p'
     p = layer.retrieve_params(data, dispatch_ctx)

--- a/src/spflow/torch/sampling/general/layers/leaves/parametric/cond_log_normal.py
+++ b/src/spflow/torch/sampling/general/layers/leaves/parametric/cond_log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondLogNormalLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -64,9 +63,9 @@ def sample(
     if any([i >= data.shape[0] for i in sampling_ctx.instance_ids]):
         raise ValueError("Some instance ids are out of bounds for data tensor.")
 
-    unique_output_signatures = set(
+    unique_output_signatures = {
         frozenset(l) for l in sampling_ctx.output_ids
-    )
+    }
 
     # retrieve values for 'mean','std'
     mean, std = layer.retrieve_params(data, dispatch_ctx)

--- a/src/spflow/torch/sampling/general/layers/leaves/parametric/cond_multivariate_gaussian.py
+++ b/src/spflow/torch/sampling/general/layers/leaves/parametric/cond_multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondMultivariateGaussianLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/sampling/general/layers/leaves/parametric/cond_negative_binomial.py
+++ b/src/spflow/torch/sampling/general/layers/leaves/parametric/cond_negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondNegativeBinomialLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -64,9 +63,9 @@ def sample(
     if any([i >= data.shape[0] for i in sampling_ctx.instance_ids]):
         raise ValueError("Some instance ids are out of bounds for data tensor.")
 
-    unique_output_signatures = set(
+    unique_output_signatures = {
         frozenset(l) for l in sampling_ctx.output_ids
-    )
+    }
 
     # retrieve value for 'p'
     p = layer.retrieve_params(data, dispatch_ctx)

--- a/src/spflow/torch/sampling/general/layers/leaves/parametric/cond_poisson.py
+++ b/src/spflow/torch/sampling/general/layers/leaves/parametric/cond_poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondPoissonLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -64,9 +63,9 @@ def sample(
     if any([i >= data.shape[0] for i in sampling_ctx.instance_ids]):
         raise ValueError("Some instance ids are out of bounds for data tensor.")
 
-    unique_output_signatures = set(
+    unique_output_signatures = {
         frozenset(l) for l in sampling_ctx.output_ids
-    )
+    }
 
     # retrieve value for 'l'
     l = layer.retrieve_params(data, dispatch_ctx)

--- a/src/spflow/torch/sampling/general/layers/leaves/parametric/exponential.py
+++ b/src/spflow/torch/sampling/general/layers/leaves/parametric/exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``ExponentialLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -64,9 +63,9 @@ def sample(
     if any([i >= data.shape[0] for i in sampling_ctx.instance_ids]):
         raise ValueError("Some instance ids are out of bounds for data tensor.")
 
-    unique_output_signatures = set(
+    unique_output_signatures = {
         frozenset(l) for l in sampling_ctx.output_ids
-    )
+    }
 
     # make sure that no scopes are overlapping
     # TODO: suppress check

--- a/src/spflow/torch/sampling/general/layers/leaves/parametric/gamma.py
+++ b/src/spflow/torch/sampling/general/layers/leaves/parametric/gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``GammaLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -64,9 +63,9 @@ def sample(
     if any([i >= data.shape[0] for i in sampling_ctx.instance_ids]):
         raise ValueError("Some instance ids are out of bounds for data tensor.")
 
-    unique_output_signatures = set(
+    unique_output_signatures = {
         frozenset(l) for l in sampling_ctx.output_ids
-    )
+    }
 
     # make sure that no scopes are overlapping
     # TODO: suppress check

--- a/src/spflow/torch/sampling/general/layers/leaves/parametric/gaussian.py
+++ b/src/spflow/torch/sampling/general/layers/leaves/parametric/gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``GaussianLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -64,9 +63,9 @@ def sample(
     if any([i >= data.shape[0] for i in sampling_ctx.instance_ids]):
         raise ValueError("Some instance ids are out of bounds for data tensor.")
 
-    unique_output_signatures = set(
+    unique_output_signatures = {
         frozenset(l) for l in sampling_ctx.output_ids
-    )
+    }
 
     # make sure that no scopes are overlapping
     # TODO: suppress check

--- a/src/spflow/torch/sampling/general/layers/leaves/parametric/geometric.py
+++ b/src/spflow/torch/sampling/general/layers/leaves/parametric/geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``GeometricLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -64,9 +63,9 @@ def sample(
     if any([i >= data.shape[0] for i in sampling_ctx.instance_ids]):
         raise ValueError("Some instance ids are out of bounds for data tensor.")
 
-    unique_output_signatures = set(
+    unique_output_signatures = {
         frozenset(l) for l in sampling_ctx.output_ids
-    )
+    }
 
     # make sure that no scopes are overlapping
     # TODO: suppress check

--- a/src/spflow/torch/sampling/general/layers/leaves/parametric/hypergeometric.py
+++ b/src/spflow/torch/sampling/general/layers/leaves/parametric/hypergeometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``HypergeometricLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -64,9 +63,9 @@ def sample(
     if any([i >= data.shape[0] for i in sampling_ctx.instance_ids]):
         raise ValueError("Some instance ids are out of bounds for data tensor.")
 
-    unique_output_signatures = set(
+    unique_output_signatures = {
         frozenset(l) for l in sampling_ctx.output_ids
-    )
+    }
 
     # make sure that no scopes are overlapping
     # TODO: suppress check

--- a/src/spflow/torch/sampling/general/layers/leaves/parametric/log_normal.py
+++ b/src/spflow/torch/sampling/general/layers/leaves/parametric/log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``LogNormalLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -64,9 +63,9 @@ def sample(
     if any([i >= data.shape[0] for i in sampling_ctx.instance_ids]):
         raise ValueError("Some instance ids are out of bounds for data tensor.")
 
-    unique_output_signatures = set(
+    unique_output_signatures = {
         frozenset(l) for l in sampling_ctx.output_ids
-    )
+    }
 
     # make sure that no scopes are overlapping
     # TODO: suppress check

--- a/src/spflow/torch/sampling/general/layers/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/torch/sampling/general/layers/leaves/parametric/multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``MultivariateGaussianLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 import torch

--- a/src/spflow/torch/sampling/general/layers/leaves/parametric/negative_binomial.py
+++ b/src/spflow/torch/sampling/general/layers/leaves/parametric/negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``PoissonLayer`` leaves for SPFlow in the ``base`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -64,9 +63,9 @@ def sample(
     if any([i >= data.shape[0] for i in sampling_ctx.instance_ids]):
         raise ValueError("Some instance ids are out of bounds for data tensor.")
 
-    unique_output_signatures = set(
+    unique_output_signatures = {
         frozenset(l) for l in sampling_ctx.output_ids
-    )
+    }
 
     # make sure that no scopes are overlapping
     # TODO: suppress check

--- a/src/spflow/torch/sampling/general/layers/leaves/parametric/poisson.py
+++ b/src/spflow/torch/sampling/general/layers/leaves/parametric/poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``PoissonLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -64,9 +63,9 @@ def sample(
     if any([i >= data.shape[0] for i in sampling_ctx.instance_ids]):
         raise ValueError("Some instance ids are out of bounds for data tensor.")
 
-    unique_output_signatures = set(
+    unique_output_signatures = {
         frozenset(l) for l in sampling_ctx.output_ids
-    )
+    }
 
     # make sure that no scopes are overlapping
     # TODO: suppress check

--- a/src/spflow/torch/sampling/general/layers/leaves/parametric/uniform.py
+++ b/src/spflow/torch/sampling/general/layers/leaves/parametric/uniform.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``UniformLayer`` leaves for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -64,9 +63,9 @@ def sample(
     if any([i >= data.shape[0] for i in sampling_ctx.instance_ids]):
         raise ValueError("Some instance ids are out of bounds for data tensor.")
 
-    unique_output_signatures = set(
+    unique_output_signatures = {
         frozenset(l) for l in sampling_ctx.output_ids
-    )
+    }
 
     # make sure that no scopes are overlapping
     # TODO: suppress check

--- a/src/spflow/torch/sampling/general/nodes/leaves/parametric/bernoulli.py
+++ b/src/spflow/torch/sampling/general/nodes/leaves/parametric/bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``Bernoulli`` nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/general/nodes/leaves/parametric/binomial.py
+++ b/src/spflow/torch/sampling/general/nodes/leaves/parametric/binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``Binomial`` nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/general/nodes/leaves/parametric/cond_bernoulli.py
+++ b/src/spflow/torch/sampling/general/nodes/leaves/parametric/cond_bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondBernoulli`` nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/general/nodes/leaves/parametric/cond_binomial.py
+++ b/src/spflow/torch/sampling/general/nodes/leaves/parametric/cond_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondBinomial`` nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/general/nodes/leaves/parametric/cond_exponential.py
+++ b/src/spflow/torch/sampling/general/nodes/leaves/parametric/cond_exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondExponential`` nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/general/nodes/leaves/parametric/cond_gamma.py
+++ b/src/spflow/torch/sampling/general/nodes/leaves/parametric/cond_gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondGamma`` nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/general/nodes/leaves/parametric/cond_gaussian.py
+++ b/src/spflow/torch/sampling/general/nodes/leaves/parametric/cond_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondGaussian`` nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/general/nodes/leaves/parametric/cond_geometric.py
+++ b/src/spflow/torch/sampling/general/nodes/leaves/parametric/cond_geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondGeometric`` nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/general/nodes/leaves/parametric/cond_log_normal.py
+++ b/src/spflow/torch/sampling/general/nodes/leaves/parametric/cond_log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondLogNormal`` nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/general/nodes/leaves/parametric/cond_multivariate_gaussian.py
+++ b/src/spflow/torch/sampling/general/nodes/leaves/parametric/cond_multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondMultivariateGaussian`` nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/general/nodes/leaves/parametric/cond_negative_binomial.py
+++ b/src/spflow/torch/sampling/general/nodes/leaves/parametric/cond_negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondNegativeBinomial`` nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/general/nodes/leaves/parametric/cond_poisson.py
+++ b/src/spflow/torch/sampling/general/nodes/leaves/parametric/cond_poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``CondPoisson`` nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/general/nodes/leaves/parametric/exponential.py
+++ b/src/spflow/torch/sampling/general/nodes/leaves/parametric/exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``Exponential`` nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/general/nodes/leaves/parametric/gamma.py
+++ b/src/spflow/torch/sampling/general/nodes/leaves/parametric/gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``Gamma`` nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/general/nodes/leaves/parametric/gaussian.py
+++ b/src/spflow/torch/sampling/general/nodes/leaves/parametric/gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``Gaussian`` nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/general/nodes/leaves/parametric/geometric.py
+++ b/src/spflow/torch/sampling/general/nodes/leaves/parametric/geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``Geometric`` nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/general/nodes/leaves/parametric/hypergeometric.py
+++ b/src/spflow/torch/sampling/general/nodes/leaves/parametric/hypergeometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``Hypergeometric`` nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/general/nodes/leaves/parametric/log_normal.py
+++ b/src/spflow/torch/sampling/general/nodes/leaves/parametric/log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``LogNormal`` nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/general/nodes/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/torch/sampling/general/nodes/leaves/parametric/multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``MultivariateGaussian`` nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/general/nodes/leaves/parametric/negative_binomial.py
+++ b/src/spflow/torch/sampling/general/nodes/leaves/parametric/negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``NegativeBinomial`` nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/general/nodes/leaves/parametric/poisson.py
+++ b/src/spflow/torch/sampling/general/nodes/leaves/parametric/poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``Poisson`` nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/general/nodes/leaves/parametric/uniform.py
+++ b/src/spflow/torch/sampling/general/nodes/leaves/parametric/uniform.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``Uniform`` nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/module.py
+++ b/src/spflow/torch/sampling/module.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``Module`` for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/nested_module.py
+++ b/src/spflow/torch/sampling/nested_module.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for ``NestedModule`` for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/spn/layers/cond_sum_layer.py
+++ b/src/spflow/torch/sampling/spn/layers/cond_sum_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for conditional SPN-like layers for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/spn/layers/hadamard_layer.py
+++ b/src/spflow/torch/sampling/spn/layers/hadamard_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for SPN-like Hadamard layers for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/spn/layers/partition_layer.py
+++ b/src/spflow/torch/sampling/spn/layers/partition_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for SPN-like partition layers for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/spn/layers/product_layer.py
+++ b/src/spflow/torch/sampling/spn/layers/product_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for SPN-like product layers for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/spn/layers/sum_layer.py
+++ b/src/spflow/torch/sampling/spn/layers/sum_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for SPN-like sum layers for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/spn/nodes/cond_sum_node.py
+++ b/src/spflow/torch/sampling/spn/nodes/cond_sum_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for conditional SPN-like nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/spn/nodes/product_node.py
+++ b/src/spflow/torch/sampling/spn/nodes/product_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for SPN-like product nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/spn/nodes/sum_node.py
+++ b/src/spflow/torch/sampling/spn/nodes/sum_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for SPN-like nodes for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/sampling/spn/rat/rat_spn.py
+++ b/src/spflow/torch/sampling/spn/rat/rat_spn.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains sampling methods for RAT-SPNs for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch

--- a/src/spflow/torch/structure/autoleaf.py
+++ b/src/spflow/torch/structure/autoleaf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """TODO
 """
 from typing import Tuple, List, Union, Optional, Dict, Type

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/bernoulli.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Bernoulli leaf layer for SPFlow in the ``torch`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple
@@ -98,7 +97,7 @@ class BernoulliLayer(Module):
                     f"Evidence scope for 'BernoulliLayer' should be empty, but was {s.evidence}."
                 )
 
-        super(BernoulliLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # register auxiliary torch parameter for the success probabilities p for each implicit node
         self.p_aux = Parameter()

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/binomial.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Binomial leaf layer for SPFlow in the ``torch`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple
@@ -104,7 +103,7 @@ class BinomialLayer(Module):
                     f"Evidence scope for 'BinomialLayer' should be empty, but was {s.evidence}."
                 )
 
-        super(BinomialLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # register number of trials n as torch buffer (should not be changed)
         self.register_buffer("n", torch.empty(size=[]))
@@ -279,7 +278,7 @@ class BinomialLayer(Module):
                 f"Values for 'n' of 'BinomialLayer' must to greater of equal to 0, but was: {n}"
             )
 
-        if not torch.all((torch.remainder(n, 1.0) == torch.tensor(0.0))):
+        if not torch.all(torch.remainder(n, 1.0) == torch.tensor(0.0)):
             raise ValueError(
                 f"Values for 'n' of 'BinomialLayer' must be (equal to) an integer value, but was: {n}"
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_bernoulli.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Bernoulli leaf layer for SPFlow in the ``torch`` backend.
 """
 from typing import List, Union, Optional, Iterable, Callable
@@ -101,7 +100,7 @@ class CondBernoulliLayer(Module):
                     f"Evidence scope for 'CondBernoulliLayer' should not be empty."
                 )
 
-        super(CondBernoulliLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # compute scope
         self.scopes_out = scope

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_binomial.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Binomial leaf layer for SPFlow in the ``torch`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Callable
@@ -108,7 +107,7 @@ class CondBinomialLayer(Module):
                     f"Evidence scope for 'CondBinomialLayer' should not be empty."
                 )
 
-        super(CondBinomialLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # register number of trials n as torch buffer (should not be changed)
         self.register_buffer("n", torch.empty(size=[]))
@@ -333,7 +332,7 @@ class CondBinomialLayer(Module):
                 f"Values for 'n' of 'BinomialLayer' must to greater of equal to 0, but was: {n}"
             )
 
-        if not torch.all((torch.remainder(n, 1.0) == torch.tensor(0.0))):
+        if not torch.all(torch.remainder(n, 1.0) == torch.tensor(0.0)):
             raise ValueError(
                 f"Values for 'n' of 'BinomialLayer' must be (equal to) an integer value, but was: {n}"
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_exponential.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Exponential leaf layer for SPFlow in the ``torch`` backend.
 """
 from typing import List, Union, Optional, Iterable, Callable
@@ -99,7 +98,7 @@ class CondExponentialLayer(Module):
                     f"Evidence scope for 'CondExponentialLayer' should not be empty."
                 )
 
-        super(CondExponentialLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # compute scope
         self.scopes_out = scope

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_gamma.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Gamma leaf layer for SPFlow in the ``torch`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Callable
@@ -101,7 +100,7 @@ class CondGammaLayer(Module):
                     f"Evidence scope for 'CondGammaLayer' should not be empty."
                 )
 
-        super(CondGammaLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # compute scope
         self.scopes_out = scope

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_gaussian.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Gaussian leaf layer for SPFlow in the ``torch`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Callable
@@ -99,7 +98,7 @@ class CondGaussianLayer(Module):
                     f"Evidence scope for 'CondGaussianLayer' should not be empty."
                 )
 
-        super(CondGaussianLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # compute scope
         self.scopes_out = scope

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_geometric.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Geometric leaf layer for SPFlow in the ``torch`` backend.
 """
 from typing import List, Union, Optional, Iterable, Callable
@@ -98,7 +97,7 @@ class CondGeometricLayer(Module):
                     f"Evidence scope for 'CondGeometricLayer' should not be empty."
                 )
 
-        super(CondGeometricLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # compute scope
         self.scopes_out = scope

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_log_normal.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Log-Normal leaf layer for SPFlow in the ``torch`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Callable
@@ -99,7 +98,7 @@ class CondLogNormalLayer(Module):
                     f"Evidence scope for 'CondLogNormalLayer' should not be empty."
                 )
 
-        super(CondLogNormalLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # compute scope
         self.scopes_out = scope

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_multivariate_gaussian.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Multivariate Gaussian leaf layer for SPFlow in the ``torch`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Callable
@@ -109,7 +108,7 @@ class CondMultivariateGaussianLayer(Module):
 
             self._n_out = len(scope)
 
-        super(CondMultivariateGaussianLayer, self).__init__(
+        super().__init__(
             children=[], **kwargs
         )
 

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_negative_binomial.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Negative Binomial leaf layer for SPFlow in the ``torch`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple, Callable
@@ -104,7 +103,7 @@ class CondNegativeBinomialLayer(Module):
                     f"Evidence scope for 'CondNegativeBinomialLayer' should not be empty."
                 )
 
-        super(CondNegativeBinomialLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # register number of trials n as torch buffer (should not be changed)
         self.register_buffer("n", torch.empty(size=[]))
@@ -332,7 +331,7 @@ class CondNegativeBinomialLayer(Module):
                 f"Values for 'n' of 'NegativeBinomialLayer' must to greater of equal to 0, but was: {n}"
             )
 
-        if not torch.all((torch.remainder(n, 1.0) == torch.tensor(0.0))):
+        if not torch.all(torch.remainder(n, 1.0) == torch.tensor(0.0)):
             raise ValueError(
                 f"Values for 'n' of 'NegativeBinomialLayer' must be (equal to) an integer value, but was: {n}"
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/cond_poisson.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/cond_poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Poisson leaf layer for SPFlow in the ``torch`` backend.
 """
 from typing import List, Union, Optional, Iterable, Callable
@@ -98,7 +97,7 @@ class CondPoissonLayer(Module):
                     f"Evidence scope for 'CondPoissonLayer' should not be empty."
                 )
 
-        super(CondPoissonLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # compute scope
         self.scopes_out = scope

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/exponential.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Exponential leaf layer for SPFlow in the ``torch`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple
@@ -98,7 +97,7 @@ class ExponentialLayer(Module):
                     f"Evidence scope for 'ExponentialLayer' should be empty, but was {s.evidence}."
                 )
 
-        super(ExponentialLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # register auxiliary torch parameter for rate l of each implicit node
         self.l_aux = Parameter()

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/gamma.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Gamma leaf layer for SPFlow in the ``torch`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple
@@ -105,7 +104,7 @@ class GammaLayer(Module):
                     f"Evidence scope for 'GammaLayer' should be empty, but was {s.evidence}."
                 )
 
-        super(GammaLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # register auxiliary torch parameter for rate l of each implicit node
         self.alpha_aux = Parameter()

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/gaussian.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Gaussian leaf layer for SPFlow in the ``torch`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple
@@ -105,7 +104,7 @@ class GaussianLayer(Module):
                     f"Evidence scope for 'GaussianLayer' should be empty, but was {s.evidence}."
                 )
 
-        super(GaussianLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # register auxiliary torch parameter for rate l of each implicit node
         self.mean = Parameter()

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/geometric.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Geometric leaf layer for SPFlow in the ``torche`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple
@@ -97,7 +96,7 @@ class GeometricLayer(Module):
                     f"Evidence scope for 'GeometricLayer' should be empty, but was {s.evidence}."
                 )
 
-        super(GeometricLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # register auxiliary torch parameter for success probability p of each implicit node
         self.p_aux = Parameter()

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/hypergeometric.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/hypergeometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Hypergeometric leaf layer for SPFlow in the ``torch`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple
@@ -100,7 +99,7 @@ class HypergeometricLayer(Module):
                     f"Evidence scope for 'HypergeometricLayer' should be empty, but was {s.evidence}."
                 )
 
-        super(HypergeometricLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # register number of trials n as torch buffer (should not be changed)
         self.register_buffer("N", torch.empty(size=[]))

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/log_normal.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Log-Normal leaf layer for SPFlow in the ``torch`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple
@@ -105,7 +104,7 @@ class LogNormalLayer(Module):
                     f"Evidence scope for 'LogNormalLayer' should be empty, but was {s.evidence}."
                 )
 
-        super(LogNormalLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # register auxiliary torch parameter for rate l of each implicit node
         self.mean = Parameter()

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Multivariate Gaussian leaf layer for SPFlow in the ``torch`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple
@@ -109,7 +108,7 @@ class MultivariateGaussianLayer(Module):
 
             self._n_out = len(scope)
 
-        super(MultivariateGaussianLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         if mean is None:
             mean = [torch.zeros(len(s.query)) for s in scope]

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/negative_binomial.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Negative Binomial leaf layer for SPFlow in the ``torch`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple
@@ -103,7 +102,7 @@ class NegativeBinomialLayer(Module):
                     f"Evidence scope for 'NegativeBinomialLayer' should be empty, but was {s.evidence}."
                 )
 
-        super(NegativeBinomialLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # register number of trials n as torch buffer (should not be changed)
         self.register_buffer("n", torch.empty(size=[]))
@@ -271,7 +270,7 @@ class NegativeBinomialLayer(Module):
                 f"Values for 'n' of 'NegativeBinomialLayer' must to greater of equal to 0, but was: {n}"
             )
 
-        if not torch.all((torch.remainder(n, 1.0) == torch.tensor(0.0))):
+        if not torch.all(torch.remainder(n, 1.0) == torch.tensor(0.0)):
             raise ValueError(
                 f"Values for 'n' of 'NegativeBinomialLayer' must be (equal to) an integer value, but was: {n}"
             )

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/poisson.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Poisson leaf layer for SPFlow in the ``torch`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple
@@ -95,7 +94,7 @@ class PoissonLayer(Module):
                     f"Evidence scope for 'PoissonLayer' should be empty, but was {s.evidence}."
                 )
 
-        super(PoissonLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # register auxiliary torch parameter for rate l of each implicit node
         self.l_aux = Parameter()

--- a/src/spflow/torch/structure/general/layers/leaves/parametric/uniform.py
+++ b/src/spflow/torch/structure/general/layers/leaves/parametric/uniform.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Uniform leaf node for SPFlow in the ``torch`` backend.
 """
 from typing import List, Union, Optional, Iterable, Tuple
@@ -98,7 +97,7 @@ class UniformLayer(Module):
                     f"Evidence scope for 'UniformLayer' should be empty, but was {s.evidence}."
                 )
 
-        super(UniformLayer, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         # register interval bounds as torch buffers (should not be changed)
         self.register_buffer("start", torch.empty(size=[]))

--- a/src/spflow/torch/structure/general/nodes/leaf_node.py
+++ b/src/spflow/torch/structure/general/nodes/leaf_node.py
@@ -27,6 +27,6 @@ class LeafNode(Node, ABC):
             scope:
                 Scope object representing the scope of the leaf node,
         """
-        super(LeafNode, self).__init__(children=[], **kwargs)
+        super().__init__(children=[], **kwargs)
 
         self.scope = scope

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/bernoulli.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Bernoulli leaf node for SPFlow in the ``torch`` backend.
 """
 import numpy as np
@@ -69,7 +68,7 @@ class Bernoulli(LeafNode):
                 f"Evidence scope for 'Bernoulli' should be empty, but was {scope.evidence}."
             )
 
-        super(Bernoulli, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # register auxiliary torch parameter for the success probability p
         self.p_aux = Parameter()

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/binomial.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Binomial leaf node for SPFlow in the ``torch`` backend.
 """
 import numpy as np
@@ -71,7 +70,7 @@ class Binomial(LeafNode):
                 f"Evidence scope for 'Binomial' should be empty, but was {scope.evidence}."
             )
 
-        super(Binomial, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # register number of trials n as torch buffer (should not be changed)
         self.register_buffer("n", torch.empty(size=[]))

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_bernoulli.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_bernoulli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Bernoulli leaf node for SPFlow in the ``torch`` backend.
 """
 import torch
@@ -59,7 +58,7 @@ class CondBernoulli(LeafNode):
                 f"Evidence scope for 'CondBernoulli' should not be empty."
             )
 
-        super(CondBernoulli, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         self.set_cond_f(cond_f)
 

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_binomial.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Binomial leaf node for SPFlow in the ``torch`` backend.
 """
 import torch
@@ -67,7 +66,7 @@ class CondBinomial(LeafNode):
                 f"Evidence scope for 'CondBinomial' should not be empty."
             )
 
-        super(CondBinomial, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # register number of trials n as torch buffer (should not be changed)
         self.register_buffer("n", torch.empty(size=[]))

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_exponential.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Binomial leaf node for SPFlow in the ``torch`` backend.
 """
 import torch
@@ -59,7 +58,7 @@ class CondExponential(LeafNode):
                 f"Evidence scope for 'CondExponential' should not be empty."
             )
 
-        super(CondExponential, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         self.set_cond_f(cond_f)
 

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_gamma.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Gamma leaf node for SPFlow in the ``torch`` backend.
 """
 import torch
@@ -61,7 +60,7 @@ class CondGamma(LeafNode):
                 f"Evidence scope for CondGamma should not be empty."
             )
 
-        super(CondGamma, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         self.set_cond_f(cond_f)
 

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_gaussian.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Gaussian leaf node for SPFlow in the ``torch`` backend.
 """
 import torch
@@ -59,7 +58,7 @@ class CondGaussian(LeafNode):
                 f"Evidence scope for 'CondGaussian' should not be empty."
             )
 
-        super(CondGaussian, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         self.set_cond_f(cond_f)
 

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_geometric.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Geometric leaf node for SPFlow in the ``torch`` backend.
 """
 import torch
@@ -58,7 +57,7 @@ class CondGeometric(LeafNode):
                 f"Evidence scope for 'CondGeometric' should not be empty."
             )
 
-        super(CondGeometric, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         self.set_cond_f(cond_f)
 

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_log_normal.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Log-Normal leaf node for SPFlow in the ``torch`` backend.
 """
 import torch
@@ -59,7 +58,7 @@ class CondLogNormal(LeafNode):
                 f"Evidence scope for 'CondLogNormal' should not be empty."
             )
 
-        super(CondLogNormal, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         self.set_cond_f(cond_f)
 

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_multivariate_gaussian.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Multivariate Normal leaf node for SPFlow in the ``torch`` backend.
 """
 import numpy as np
@@ -79,7 +78,7 @@ class CondMultivariateGaussian(LeafNode):
                 "Size of query scope for 'CondMultivariateGaussian' must be at least 1."
             )
 
-        super(CondMultivariateGaussian, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # dimensions
         self.d = len(scope)

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_negative_binomial.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Negative Binomial leaf node for SPFlow in the ``torch`` backend.
 """
 import numpy as np
@@ -66,7 +65,7 @@ class CondNegativeBinomial(LeafNode):
                 f"Evidence scope for 'CondNegativeBinomial' should not be empty."
             )
 
-        super(CondNegativeBinomial, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # register number of trials n as torch buffer (should not be changed)
         self.register_buffer("n", torch.empty(size=[]))

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_poisson.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/cond_poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional Poisson leaf node for SPFlow in the ``torch`` backend.
 """
 import torch
@@ -58,7 +57,7 @@ class CondPoisson(LeafNode):
                 f"Evidence scope for 'CondPoisson' should not be empty."
             )
 
-        super(CondPoisson, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         self.set_cond_f(cond_f)
 

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/exponential.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/exponential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Exponential leaf node for SPFlow in the ``torch`` backend.
 """
 import numpy as np
@@ -66,7 +65,7 @@ class Exponential(LeafNode):
                 f"Evidence scope for 'Exponential' should be empty, but was {scope.evidence}."
             )
 
-        super(Exponential, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # register auxiliary torch parameter for parameter l
         self.l_aux = Parameter()

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/gamma.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/gamma.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Gamma leaf node for SPFlow in the ``torch`` backend.
 """
 import numpy as np
@@ -77,7 +76,7 @@ class Gamma(LeafNode):
                 f"Evidence scope for 'Gamma' should be empty, but was {scope.evidence}."
             )
 
-        super(Gamma, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # register auxiliary torch parameters for alpha and beta
         self.alpha_aux = Parameter()

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/gaussian.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Gaussian leaf node for SPFlow in the ``torch`` backend.
 """
 import numpy as np
@@ -73,7 +72,7 @@ class Gaussian(LeafNode):
                 f"Evidence scope for 'Gaussian' should be empty, but was {scope.evidence}."
             )
 
-        super(Gaussian, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # register mean as torch parameter
         self.mean = Parameter()

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/geometric.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/geometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Geometric leaf node for SPFlow in the ``torch`` backend.
 """
 import numpy as np
@@ -65,7 +64,7 @@ class Geometric(LeafNode):
                 f"Evidence scope for 'Geometric' should be empty, but was {scope.evidence}."
             )
 
-        super(Geometric, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # register auxiliary torch parameter for the success probability p
         self.p_aux = Parameter()

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/hypergeometric.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/hypergeometric.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Hypergeometric leaf node for SPFlow in the ``torch`` backend.
 """
 import numpy as np
@@ -65,7 +64,7 @@ class Hypergeometric(LeafNode):
                 f"Evidence scope for 'Hypergeometric' should be empty, but was {scope.evidence}."
             )
 
-        super(Hypergeometric, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # register parameters as torch buffers (should not be changed)
         self.register_buffer("N", torch.empty(size=[]))

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/log_normal.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/log_normal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Log-Normal leaf node for SPFlow in the ``torch`` backend.
 """
 import numpy as np
@@ -76,7 +75,7 @@ class LogNormal(LeafNode):
                 f"Evidence scope for 'LogNormal' should be empty, but was {scope.evidence}."
             )
 
-        super(LogNormal, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # register mean as torch parameter
         self.mean = Parameter()

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/multivariate_gaussian.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/multivariate_gaussian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Multivariate Normal leaf node for SPFlow in the ``torch`` backend.
 """
 import numpy as np
@@ -95,7 +94,7 @@ class MultivariateGaussian(LeafNode):
                 "Size of query scope for 'MultivariateGaussian' must be at least 1."
             )
 
-        super(MultivariateGaussian, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         if mean is None:
             mean = torch.zeros((1, len(scope)))

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/negative_binomial.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/negative_binomial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Negative Binomial leaf node for SPFlow in the ``torch`` backend.
 """
 import numpy as np
@@ -70,7 +69,7 @@ class NegativeBinomial(LeafNode):
                 f"Evidence scope for 'NegativeBinomial' should be empty, but was {scope.evidence}."
             )
 
-        super(NegativeBinomial, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # register number of trials n as torch buffer (should not be changed)
         self.register_buffer("n", torch.empty(size=[]))

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/poisson.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/poisson.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Poisson leaf node for SPFlow in the ``torch`` backend.
 """
 import numpy as np
@@ -65,7 +64,7 @@ class Poisson(LeafNode):
                 f"Evidence scope for 'Poisson' should be empty, but was {scope.evidence}."
             )
 
-        super(Poisson, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # register auxiliary torch parameter for lambda l
         self.l_aux = Parameter()

--- a/src/spflow/torch/structure/general/nodes/leaves/parametric/uniform.py
+++ b/src/spflow/torch/structure/general/nodes/leaves/parametric/uniform.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains Uniform leaf node for SPFlow in the ``torch`` backend.
 """
 import numpy as np
@@ -76,7 +75,7 @@ class Uniform(LeafNode):
                 f"Evidence scope for 'Uniform' should be empty, but was {scope.evidence}."
             )
 
-        super(Uniform, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
         # register interval bounds as torch buffers (should not be changed)
         self.register_buffer("start", torch.empty(size=[]))

--- a/src/spflow/torch/structure/general/nodes/node.py
+++ b/src/spflow/torch/structure/general/nodes/node.py
@@ -45,7 +45,7 @@ class Node(Module, ABC):
         if children is None:
             children = []
 
-        super(Node, self).__init__(children=children, **kwargs)
+        super().__init__(children=children, **kwargs)
 
     @property
     def n_out(self) -> int:

--- a/src/spflow/torch/structure/module.py
+++ b/src/spflow/torch/structure/module.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains the abstract ``Module`` class for SPFlow modules in the 'torch' backend.
 
 All valid SPFlow modules in the ``torch`` backend should inherit from this class or a subclass of it.
@@ -37,7 +36,7 @@ class Module(MetaModule, nn.Module, ABC):
         Raises:
             ValueError: children of invalid type.
         """
-        super(Module, self).__init__()
+        super().__init__()
 
         if children is None:
             children = []
@@ -47,7 +46,7 @@ class Module(MetaModule, nn.Module, ABC):
 
         # register children
         for i, child in enumerate(children):
-            self.add_module("child_{}".format(i + 1), child)
+            self.add_module(f"child_{i + 1}", child)
 
     def input_to_output_ids(
         self, input_ids: Union[List[int], torch.Tensor]

--- a/src/spflow/torch/structure/nested_module.py
+++ b/src/spflow/torch/structure/nested_module.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains the abstract ``NestedModule`` class for SPFlow modules in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch_context import DispatchContext
@@ -37,7 +36,7 @@ class NestedModule(Module, ABC):
         if children is None:
             children = []
 
-        super(NestedModule, self).__init__(children=children, **kwargs)
+        super().__init__(children=children, **kwargs)
         self.placeholders = []
 
     def create_placeholder(self, input_ids: List[int]) -> "Placeholder":

--- a/src/spflow/torch/structure/spn/layers/cond_sum_layer.py
+++ b/src/spflow/torch/structure/spn/layers/cond_sum_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional SPN-like sum layer for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch
@@ -80,7 +79,7 @@ class CondSumLayer(Module):
                 "'CondSumLayer' requires at least one child to be specified."
             )
 
-        super(CondSumLayer, self).__init__(children=children, **kwargs)
+        super().__init__(children=children, **kwargs)
 
         self._n_out = n_nodes
         self.n_in = sum(child.n_out for child in self.children())

--- a/src/spflow/torch/structure/spn/layers/hadamard_layer.py
+++ b/src/spflow/torch/structure/spn/layers/hadamard_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains SPN-like hadamard layer for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -121,7 +120,7 @@ class HadamardLayer(Module):
                     "Scopes of partitions must be pair-wise disjoint."
                 )
 
-        super(HadamardLayer, self).__init__(
+        super().__init__(
             children=sum(child_partitions, []), **kwargs
         )
 

--- a/src/spflow/torch/structure/spn/layers/partition_layer.py
+++ b/src/spflow/torch/structure/spn/layers/partition_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains SPN-like partition layer for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -114,7 +113,7 @@ class PartitionLayer(Module):
                     "Scopes of partitions must be pair-wise disjoint."
                 )
 
-        super(PartitionLayer, self).__init__(
+        super().__init__(
             children=sum(child_partitions, []), **kwargs
         )
 

--- a/src/spflow/torch/structure/spn/layers/product_layer.py
+++ b/src/spflow/torch/structure/spn/layers/product_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains SPN-like product layer for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -56,7 +55,7 @@ class ProductLayer(Module):
                 "'ProductLayer' requires at least one child to be specified."
             )
 
-        super(ProductLayer, self).__init__(children=children, **kwargs)
+        super().__init__(children=children, **kwargs)
 
         # compute scope
         scope = Scope()

--- a/src/spflow/torch/structure/spn/layers/sum_layer.py
+++ b/src/spflow/torch/structure/spn/layers/sum_layer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains SPN-like sum layer for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch
@@ -82,7 +81,7 @@ class SumLayer(Module):
                 "'SumLayer' requires at least one child to be specified."
             )
 
-        super(SumLayer, self).__init__(children=children, **kwargs)
+        super().__init__(children=children, **kwargs)
 
         self._n_out = n_nodes
         self.n_in = sum(child.n_out for child in self.children())

--- a/src/spflow/torch/structure/spn/nodes/cond_sum_node.py
+++ b/src/spflow/torch/structure/spn/nodes/cond_sum_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains conditional SPN-like sum node for SPFlow in the ``torch`` backend.
 """
 from typing import List, Optional, Iterable, Callable
@@ -57,7 +56,7 @@ class CondSumNode(Node):
         Raises:
             ValueError: Invalid arguments.
         """
-        super(CondSumNode, self).__init__(children=children)
+        super().__init__(children=children)
 
         if not children:
             raise ValueError(

--- a/src/spflow/torch/structure/spn/nodes/product_node.py
+++ b/src/spflow/torch/structure/spn/nodes/product_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains ``ProductNode`` for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch
@@ -43,7 +42,7 @@ class ProductNode(Node):
         Raises:
             ValueError: Invalid arguments.
         """
-        super(ProductNode, self).__init__(children=children)
+        super().__init__(children=children)
 
         if not children:
             raise ValueError(

--- a/src/spflow/torch/structure/spn/nodes/sum_node.py
+++ b/src/spflow/torch/structure/spn/nodes/sum_node.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains ``SumNode`` for SPFlow in the ``torch`` backend.
 """
 from spflow.meta.dispatch.dispatch import dispatch
@@ -62,7 +61,7 @@ class SumNode(Node):
         Raises:
             ValueError: Invalid arguments.
         """
-        super(SumNode, self).__init__(children=children)
+        super().__init__(children=children)
 
         if not children:
             raise ValueError(

--- a/src/spflow/torch/structure/spn/rat/rat_spn.py
+++ b/src/spflow/torch/structure/spn/rat/rat_spn.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains the SPFlow architecture for Random and Tensorized Sum-Product Networks (RAT-SPNs) in the ``torch`` backend.
 """
 from spflow.meta.data.scope import Scope
@@ -68,7 +67,7 @@ class RatSPN(Module):
         n_region_nodes: int,
         n_leaf_nodes: int,
     ) -> None:
-        super(RatSPN, self).__init__(children=[])
+        super().__init__(children=[])
         r"""Initializer for ``RatSPN`` object.
 
         Args:

--- a/src/spflow/torch/utils/cca.py
+++ b/src/spflow/torch/utils/cca.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Algorithm for canonical correlation analysis (CCA) between to data sets.
 
 Typical usage example:

--- a/src/spflow/torch/utils/connected_components.py
+++ b/src/spflow/torch/utils/connected_components.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Algorithm to find connected components in an undirected graph.
 
 Typical usage example:
@@ -45,7 +44,7 @@ def connected_components(adjacency_matrix: torch.Tensor) -> List[Set[int]]:
 
         # perform breadth-first search
         visited = set()
-        active_set = set([vertices.pop()])
+        active_set = {vertices.pop()}
 
         # while there are previously unvisited vertices
         while active_set:

--- a/src/spflow/torch/utils/corrcoef.py
+++ b/src/spflow/torch/utils/corrcoef.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Algorithm to compute Pearson correlation coefficients for a data set.
 
 Typical usage example:

--- a/src/spflow/torch/utils/empirical_cdf.py
+++ b/src/spflow/torch/utils/empirical_cdf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Algorithm to compute the empirical cummulative distribution function (CDF) for input data.
 
 Typical usage example:

--- a/src/spflow/torch/utils/kmeans.py
+++ b/src/spflow/torch/utils/kmeans.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Algorithm to compute k-Means clusters from data.
 
 Typical usage example:

--- a/src/spflow/torch/utils/nearest_sym_pd.py
+++ b/src/spflow/torch/utils/nearest_sym_pd.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Algorithm to compute the closest positive definite matrix to a given matrix.
 
 Typical usage example:

--- a/src/spflow/torch/utils/projections.py
+++ b/src/spflow/torch/utils/projections.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Projections between unbounded and bounded intervals.
 
 Used for internal projections of PyTorch parameters.

--- a/src/spflow/torch/utils/randomized_dependency_coefficients.py
+++ b/src/spflow/torch/utils/randomized_dependency_coefficients.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Algorithm to compute randomized dependency coefficients (RDCs) for a data set.
 
 Typical usage example:

--- a/src/spflow/torch/utils/rankdata.py
+++ b/src/spflow/torch/utils/rankdata.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Algorithm to compute the ranks of specified data.
 
 Typical usage example:

--- a/src/tests/base/structure/dummy_module.py
+++ b/src/tests/base/structure/dummy_module.py
@@ -13,7 +13,7 @@ class DummyModule(Module):
         self.scope = scope
         self.n = n
 
-        super(DummyModule, self).__init__(children=[])
+        super().__init__(children=[])
 
     @property
     def n_out(self) -> int:
@@ -27,7 +27,7 @@ class DummyModule(Module):
 class DummyNestedModule(NestedModule):
     def __init__(self, children):
 
-        super(DummyNestedModule, self).__init__(children=children)
+        super().__init__(children=children)
 
         self.n_in = sum([child.n_out for child in children])
         self.create_placeholder(list(range(self.n_in)))

--- a/src/tests/base/structure/general/nodes/dummy_node.py
+++ b/src/tests/base/structure/general/nodes/dummy_node.py
@@ -17,7 +17,7 @@ class DummyNode(LeafNode):
         if scope is None:
             scope = Scope([0])
 
-        super(DummyNode, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
 
 @dispatch(memoize=True)

--- a/src/tests/meta/data/test_feature_context.py
+++ b/src/tests/meta/data/test_feature_context.py
@@ -10,7 +10,7 @@ class TestFeatureContext(unittest.TestCase):
         # make sure scope is correctly stored
         self.assertEqual(Scope([0, 1, 2, 3]), feature_ctx.scope)
         # make sure default domains are correctly set
-        self.assertTrue(set(feature_ctx.domain_map.keys()) == set([0, 1, 2, 3]))
+        self.assertTrue(set(feature_ctx.domain_map.keys()) == {0, 1, 2, 3})
         self.assertTrue(
             all(
                 [

--- a/src/tests/torch/structure/dummy_module.py
+++ b/src/tests/torch/structure/dummy_module.py
@@ -13,7 +13,7 @@ class DummyModule(Module):
         self.scope = scope
         self.n = n
 
-        super(DummyModule, self).__init__(children=[])
+        super().__init__(children=[])
 
     @property
     def n_out(self) -> int:
@@ -27,7 +27,7 @@ class DummyModule(Module):
 class DummyNestedModule(NestedModule):
     def __init__(self, children):
 
-        super(DummyNestedModule, self).__init__(children=children)
+        super().__init__(children=children)
 
         self.n_in = sum([child.n_out for child in children])
         self.create_placeholder(list(range(self.n_in)))

--- a/src/tests/torch/structure/general/nodes/dummy_node.py
+++ b/src/tests/torch/structure/general/nodes/dummy_node.py
@@ -20,7 +20,7 @@ class DummyNode(LeafNode):
 
         self.loc = torch.tensor(loc)
 
-        super(DummyNode, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
 
 @dispatch(memoize=True)
@@ -62,7 +62,7 @@ class DummyLeaf(LeafNode):
 
         self.loc = torch.tensor(loc)
 
-        super(DummyLeaf, self).__init__(scope=scope)
+        super().__init__(scope=scope)
 
 
 @dispatch(memoize=True)


### PR DESCRIPTION
I ran the [pyupgrade](https://github.com/asottile/pyupgrade) tool to update some old code. It would be tedious to do this manually. 

Do you agree with the changes?

To reproduce:
```shell
pip install pyupgrade
python -m pyupgrade --py36-plus $(find . -name "*.py")
```

What is the lowest python version supported by the library? I couldn't find that info. I guess 3.8 could be sensible based on [the end-of-life dates](https://endoflife.date/python). I ran it for 3.6, but can quickly extend it to also include changes geared to higher versions.