### PR TITLE
Additional MSPN options to improve performance tabular data

### DIFF
--- a/src/spn/algorithms/StructureLearning.py
+++ b/src/spn/algorithms/StructureLearning.py
@@ -23,6 +23,7 @@ from spn.algorithms.Validity import is_valid
 from spn.structure.Base import Product, Sum, assign_ids
 import multiprocessing
 import os
+from spn.structure.leaves.histogram.Histograms import create_histogram_leaf
 
 parallel = True
 
@@ -96,7 +97,7 @@ def get_next_operation(min_instances_slice=100, min_features_slice=1, multivaria
                 return Operation.SPLIT_ROWS, None
             else:
                 return Operation.SPLIT_COLUMNS, None
-
+            
         return Operation.SPLIT_COLUMNS, None
 
     return next_operation
@@ -121,6 +122,8 @@ def learn_structure(
     next_operation=get_next_operation(),
     initial_scope=None,
     data_slicer=default_slicer,
+    alpha=1.0,
+    n_clusters=2
 ):
     assert dataset is not None
     assert ds_context is not None
@@ -131,7 +134,7 @@ def learn_structure(
 
     root = Product()
     root.children.append(None)
-
+    
     if initial_scope is None:
         initial_scope = list(range(dataset.shape[1]))
         num_conditional_cols = None
@@ -147,7 +150,7 @@ def learn_structure(
     while tasks:
 
         local_data, parent, children_pos, scope, no_clusters, no_independencies = tasks.popleft()
-
+        
         operation, op_params = next_operation(
             local_data,
             scope,
@@ -158,7 +161,7 @@ def learn_structure(
         )
 
         logging.debug("OP: {} on slice {} (remaining tasks {})".format(operation, local_data.shape, len(tasks)))
-
+        
         if operation == Operation.REMOVE_UNINFORMATIVE_FEATURES:
             node = Product()
             node.scope.extend(scope)
@@ -206,7 +209,7 @@ def learn_structure(
             continue
 
         elif operation == Operation.SPLIT_ROWS:
-
+            
             split_start_t = perf_counter()
             data_slices = split_rows(local_data, ds_context, scope)
             split_end_t = perf_counter()
@@ -272,7 +275,8 @@ def learn_structure(
                 local_tasks.append(len(node.children) - 1)
                 child_data_slice = data_slicer(local_data, [col], num_conditional_cols)
                 local_children_params.append((child_data_slice, ds_context, [scope[col]]))
-
+            
+            create_leaf = create_histogram_leaf
             result_nodes = pool.starmap(create_leaf, local_children_params)
             # result_nodes = []
             # for l in tqdm(local_children_params):
@@ -291,7 +295,7 @@ def learn_structure(
 
         elif operation == Operation.CREATE_LEAF:
             leaf_start_t = perf_counter()
-            node = create_leaf(local_data, ds_context, scope)
+            node = create_leaf(local_data, ds_context, scope, alpha=alpha)
             parent.children[children_pos] = node
             leaf_end_t = perf_counter()
 

--- a/src/spn/algorithms/StructureLearning.py
+++ b/src/spn/algorithms/StructureLearning.py
@@ -276,7 +276,6 @@ def learn_structure(
                 child_data_slice = data_slicer(local_data, [col], num_conditional_cols)
                 local_children_params.append((child_data_slice, ds_context, [scope[col]]))
             
-            create_leaf = create_histogram_leaf
             result_nodes = pool.starmap(create_leaf, local_children_params)
             # result_nodes = []
             # for l in tqdm(local_children_params):

--- a/src/spn/algorithms/splitting/Clustering.py
+++ b/src/spn/algorithms/splitting/Clustering.py
@@ -1,6 +1,5 @@
 """
 Created on March 25, 2018
-
 @author: Alejandro Molina
 """
 import numpy as np
@@ -10,6 +9,7 @@ from sklearn.metrics import pairwise
 
 from spn.algorithms.splitting.Base import split_data_by_clusters, preproc
 import logging
+from sklearn.preprocessing import StandardScaler
 
 logger = logging.getLogger(__name__)
 _rpy_initialized = False
@@ -33,14 +33,18 @@ def init_rpy():
     numpy2ri.activate()
 
 
-def get_split_rows_KMeans(n_clusters=2, pre_proc=None, ohe=False, seed=17):
+def get_split_rows_KMeans(n_clusters=2, pre_proc=None, ohe=False, seed=17, standardize=False):
     def split_rows_KMeans(local_data, ds_context, scope):
         data = preproc(local_data, ds_context, pre_proc, ohe)
-
-        clusters = KMeans(n_clusters=n_clusters, random_state=seed).fit_predict(data)
-
+        
+        if standardize:
+            scaler = StandardScaler().fit(data)
+            standardized_data = scaler.transform(data)
+            clusters = KMeans(n_clusters=n_clusters, random_state=seed,init="random").fit_predict(standardized_data)
+        else:
+            clusters = KMeans(n_clusters=n_clusters, random_state=seed).fit_predict(data)
         return split_data_by_clusters(local_data, clusters, scope, rows=True)
-
+    
     return split_rows_KMeans
 
 

--- a/src/spn/structure/leaves/histogram/Histograms.py
+++ b/src/spn/structure/leaves/histogram/Histograms.py
@@ -87,7 +87,7 @@ def create_histogram_leaf(data, ds_context, scope, alpha=1.0, hist_source="numpy
         breaks, densities, repr_points = getHistogramVals(data, meta_type, domain, source=hist_source)
 
     # laplace smoothing
-    if alpha:
+    if alpha>0:
         n_samples = data.shape[0]
         n_bins = len(breaks) - 1
         counts = densities * n_samples
@@ -143,7 +143,7 @@ def getHistogramVals(data, meta_type, domain, source="numpy"):
         densities, breaks = np.histogram(data, bins="auto", density=True)
         mids = ((breaks + np.roll(breaks, -1)) / 2.0)[:-1]
         return breaks, densities, mids
-
+    
     if source == "astropy":
         from astropy.stats import histogram
 


### PR DESCRIPTION
Three additions are requested:
1. To add the option for standardization in k-means clustering. When using tabular data, variables on a different scale (such as age and income) can have very different impact on the clustering when this may not be desired. 
2. To add the option to omit the Laplace/alpha smoothing for histograms. When the clusters significantly differ in size this could lead to bias or otherwise undesired results.
3. To add the option for the number of clusters. This was already incorporated in some of the algorithms, but not yet in the learn_mspn function. By incorporating it there as well, this option can be used. Constructing the clusters (for the sum node) at once, can have better performance than recursive clustering in 2, which can be useful if a sum node with more than two children is desired. 

All changes requested are resulting from applying the MSPN to tabular data as a method to create synthetic, privacy-preserving tabular data from the published work: https://academic.oup.com/jamia/article-abstract/30/1/16/6760688.
