### PR TITLE
fix(sum): clamp -inf log-gradients in EM to prevent NaN weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed sum weights possibly becoming NaN during EM-based optimization
+
 ## [1.0.2] - 2026-03-07
 
 ### Fixed

--- a/spflow/modules/sums/sum.py
+++ b/spflow/modules/sums/sum.py
@@ -423,6 +423,7 @@ class Sum(Module):
             input_lls = rearrange(input_lls, "b f ci r -> b f ci 1 r")
             module_lls = rearrange(module_lls, "b f co r -> b f 1 co r")
 
+            log_grads = torch.clamp(log_grads, min=torch.finfo(log_grads.dtype).min)
             log_expectations = log_weights + log_grads + input_lls - module_lls
             log_expectations = log_expectations.logsumexp(0)  # Sum over batch dimension
             log_expectations = log_expectations.log_softmax(self.sum_dim)  # Normalize


### PR DESCRIPTION
During parameter optimization with Expectation-Maximization, the sum weights may underflow, leading to NaN weights. Clamping them to the minimum float value provided by PyTorch prevents that.

EDIT: After reevaluation, it is not the sum weights that underflow, but the likelihood gradients. In very deep PCs (e.g. a chain-structured PC of length 1024), the gradients may vanish. The module_lls.grad being 0 leads to their log becoming -inf, which in turn is transformed to NaN in the following log_expectations.log_softmax(). This NaN is propagated to the sum weights in the EM update. The clamp prevents this error, but does not mitigate the vanishing gradients. We might replace the minimum float value with an epsilon parameter later.